### PR TITLE
Add packages cmd

### DIFF
--- a/add-pkg.js
+++ b/add-pkg.js
@@ -42,7 +42,7 @@ async function run () {
 
     let packageJSON = JSON.stringify({
       name: `${namespace}/${pkgName}`,
-      version: "0.0.1",
+      version: "0.0.0",
       main: entryPoint,
       license: "ISC",
       author: "Atlassian",

--- a/add-pkg.js
+++ b/add-pkg.js
@@ -1,0 +1,33 @@
+const { execSync } = require("child_process");
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+const inquirer = require('inquirer');
+
+
+async function run () {
+  const namespace = "@gwyneplaine";
+  let [pkg, format] = process.argv.splice(2);
+  let folderPath = path.resolve(__dirname, `packages/${pkg}`);
+  try {
+    if (fs.existsSync(folderPath)) {
+      throw Error(`Could not create ${pkg}. \nFolder already exists in ${folderPath}`);
+    }
+
+    let packageJSON = JSON.stringify({
+      name: `${namespace}/${pkg}`,
+      version: "0.0.1",
+      main: `index.${format}`,
+      license: "ISC",
+      author: "Atlassian",
+    }, "utf-8", 2);
+
+    fs.mkdirSync(`${folderPath}`);
+    fs.writeFileSync(`${folderPath}/package.json`, packageJSON);
+  } catch (e) {
+    console.error(chalk.red(e));
+  }
+}
+
+
+run();

--- a/add-pkg.js
+++ b/add-pkg.js
@@ -7,23 +7,49 @@ const inquirer = require('inquirer');
 
 async function run () {
   const namespace = "@gwyneplaine";
-  let [pkg, format] = process.argv.splice(2);
-  let folderPath = path.resolve(__dirname, `packages/${pkg}`);
+
+  const pkgName = await inquirer.prompt([{
+    message: "First, what is the name of your new package?",
+    name: 'pkgName',
+    validate: input => input.length > 0
+  }]).then(responses => {
+    return responses.pkgName
+  });
+
+  const entryPoint = await inquirer.prompt([{
+    message: "Next, please the entrypoint for your package? (i.e. index.js)",
+    name: 'entryPoint',
+    validate: input => input.length > 0
+  }]).then(responses => responses.entryPoint);
+
+  const packageConfig = await inquirer.prompt([{
+    message: 'Please specify your package manager (npm is the default)',
+    name: 'packageManager',
+  }]).then(({ packageManager }) => {
+    switch (packageManager.toLowerCase()) {
+      case 'npm':
+      default:
+        return 'package.json'
+    }
+  });
+
+  let folderPath = path.resolve(__dirname, `packages/${pkgName}`);
+
   try {
     if (fs.existsSync(folderPath)) {
-      throw Error(`Could not create ${pkg}. \nFolder already exists in ${folderPath}`);
+      throw Error(`Could not create ${pkgName}. \nFolder already exists in ${folderPath}`);
     }
 
     let packageJSON = JSON.stringify({
-      name: `${namespace}/${pkg}`,
+      name: `${namespace}/${pkgName}`,
       version: "0.0.1",
-      main: `index.${format}`,
+      main: entryPoint,
       license: "ISC",
       author: "Atlassian",
     }, "utf-8", 2);
 
     fs.mkdirSync(`${folderPath}`);
-    fs.writeFileSync(`${folderPath}/package.json`, packageJSON);
+    fs.writeFileSync(`${folderPath}/${packageConfig}`, packageJSON);
   } catch (e) {
     console.error(chalk.red(e));
   }

--- a/add-pkg.js
+++ b/add-pkg.js
@@ -27,6 +27,7 @@ async function run () {
     name: 'packageManager',
   }]).then(({ packageManager }) => {
     switch (packageManager.toLowerCase()) {
+      // TODO Add cocoapods support
       case 'npm':
       default:
         return 'package.json'

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "changeset": "build-releases changeset",
     "release:version": "build-releases version",
     "release:publish": "build-releases publish --public",
-    "test": "jest"
+    "test": "jest",
+    "add:package": "node ./add-pkg.js"
   },
   "dependencies": {
+    "chalk": "^2.4.2",
+    "inquirer": "^6.3.1",
     "lodash": "^4.17.11",
     "style-dictionary": "^2.7.0"
   },

--- a/packages/design-systems-iOS/package.json
+++ b/packages/design-systems-iOS/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@gwyneplaine/design-systems-iOS",
-  "version": "0.0.1",
-  "main": "index.ts",
-  "license": "ISC",
-  "author": "Atlassian"
-}

--- a/packages/design-systems-iOS/package.json
+++ b/packages/design-systems-iOS/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@gwyneplaine/design-systems-iOS",
+  "version": "0.0.1",
+  "main": "index.ts",
+  "license": "ISC",
+  "author": "Atlassian"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,6 +2144,25 @@ inquirer@^6.2.0:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
+inquirer@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
 install-packages@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/install-packages/-/install-packages-0.2.5.tgz#b50bfe3c2a36081850ba0d8c661fa6f11caeaa9e"
@@ -4637,7 +4656,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==


### PR DESCRIPTION
We now have a rudimentary CLI for adding new packages/formats to our repository. 
The new command is `yarn add:package` this will trigger a series of CLI prompts to deduce the name of the package, its entry-point and package manager of choice.

On completion of the prompts the script will create a new package in the packages workspace with the name you've specified as well as a package config with the relevant package name and specified entrypoint. At the moment the only supported package manager is npm, however I've tried to make this easy to extend in the future. 

Feedback welcome and greatly appreciated

Future changes to this should include:
- investigating piping through the CLI prompt from the CLI for each respective package manager
  - i.e. if the specified package manger is npm, we could run `yarn init` in a child_process and pipe through the subsequent prompts to our main process. 
