### PR TITLE
Snapshot tests

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,1431 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`on yarn build output files should match snapshots css 1`] = `
+"
+
+:root {
+ --r_50: #FFEBE6;
+ --r_75: #FFBDAD;
+ --r_100: #FF8F73;
+ --r_200: #FF7452;
+ --r_300: #FF5630;
+ --r_400: #DE350B;
+ --r_500: #BF2600;
+ --y_50: #FFFAE6;
+ --y_75: #FFF0B3;
+ --y_100: #FFE380;
+ --y_200: #FFC400;
+ --y_300: #FFAB00;
+ --y_400: #FF991F;
+ --y_500: #FF8B00;
+ --g_50: #E3FCEF;
+ --g_75: #ABF5D1;
+ --g_100: #79F2C0;
+ --g_200: #57D9A3;
+ --g_300: #36B37E;
+ --g_400: #00875A;
+ --g_500: #006644;
+ --b_50: #DEEBFF;
+ --b_75: #B3D4FF;
+ --b_100: #4C9AFF;
+ --b_200: #2684FF;
+ --b_300: #0065FF;
+ --b_400: #0052CC;
+ --b_500: #0747A6;
+ --p_50: #EAE6FF;
+ --p_75: #C0B6F2;
+ --p_100: #998DD9;
+ --p_200: #8777D9;
+ --p_300: #6554C0;
+ --p_400: #5243AA;
+ --p_500: #403294;
+ --t_50: #E6FCFF;
+ --t_75: #B3F5FF;
+ --t_100: #79E2F2;
+ --t_200: #00C7E6;
+ --t_300: #00B8D9;
+ --t_400: #00A3BF;
+ --t_500: #008DA6;
+ --n_0: #FFFFFF;
+ --n_10: #FAFBFC;
+ --n_20: #F4F5F7;
+ --n_30: #EBECF0;
+ --n_40: #DFE1E6;
+ --n_50: #C1C7D0;
+ --n_60: #B3BAC5;
+ --n_70: #A5ADBA;
+ --n_80: #97A0AF;
+ --n_90: #8993A4;
+ --n_100: #7A869A;
+ --n_200: #6B778C;
+ --n_300: #5E6C84;
+ --n_400: #505F79;
+ --n_500: #42526E;
+ --n_600: #344563;
+ --n_700: #253858;
+ --n_800: #172B4D;
+ --n_900: #091E42;
+ --n_10_a: rgba(9, 30, 66, 0.02);
+ --n_20_a: rgba(9, 30, 66, 0.04);
+ --n_30_a: rgba(9, 30, 66, 0.08);
+ --n_40_a: rgba(9, 30, 66, 0.13);
+ --n_50_a: rgba(9, 30, 66, 0.25);
+ --n_60_a: rgba(9, 30, 66, 0.31);
+ --n_70_a: rgba(9, 30, 66, 0.36);
+ --n_80_a: rgba(9, 30, 66, 0.42);
+ --n_90_a: rgba(9, 30, 66, 0.48);
+ --n_100_a: rgba(9, 30, 66, 0.54);
+ --n_200_a: rgba(9, 30, 66, 0.60);
+ --n_300_a: rgba(9, 30, 66, 0.66);
+ --n_400_a: rgba(9, 30, 66, 0.71);
+ --n_500_a: rgba(9, 30, 66, 0.77);
+ --n_600_a: rgba(9, 30, 66, 0.82);
+ --n_700_a: rgba(9, 30, 66, 0.89);
+ --n_800_a: rgba(9, 30, 66, 0.95);
+ --dn_900: #E6EDFA;
+ --dn_800: #DCE5F5;
+ --dn_700: #CED9EB;
+ --dn_600: #B8C7E0;
+ --dn_500: #ABBBD6;
+ --dn_400: #9FB0CC;
+ --dn_300: #8C9CB8;
+ --dn_200: #7988A3;
+ --dn_100: #67758F;
+ --dn_90: #56637A;
+ --dn_80: #455166;
+ --dn_70: #3B475C;
+ --dn_60: #313D52;
+ --dn_50: #283447;
+ --dn_40: #202B3D;
+ --dn_30: #1B2638;
+ --dn_20: #121A29;
+ --dn_10: #0E1624;
+ --dn_0: #0D1424;
+ --dn_800_a: rgba(13, 20, 36, 0.06);
+ --dn_700_a: rgba(13, 20, 36, 0.14);
+ --dn_600_a: rgba(13, 20, 36, 0.18);
+ --dn_500_a: rgba(13, 20, 36, 0.29);
+ --dn_400_a: rgba(13, 20, 36, 0.36);
+ --dn_300_a: rgba(13, 20, 36, 0.40);
+ --dn_200_a: rgba(13, 20, 36, 0.47);
+ --dn_100_a: rgba(13, 20, 36, 0.53);
+ --dn_90_a: rgba(13, 20, 36, 0.63);
+ --dn_80_a: rgba(13, 20, 36, 0.73);
+ --dn_70_a: rgba(13, 20, 36, 0.78);
+ --dn_60_a: rgba(13, 20, 36, 0.81);
+ --dn_50_a: rgba(13, 20, 36, 0.85);
+ --dn_40_a: rgba(13, 20, 36, 0.89);
+ --dn_30_a: rgba(13, 20, 36, 0.92);
+ --dn_20_a: rgba(13, 20, 36, 0.95);
+ --dn_10_a: rgba(13, 20, 36, 0.97);
+}
+"
+`;
+
+exports[`on yarn build output files should match snapshots css 2`] = `
+"
+
+:root {
+ --r_50: #FFEBE6;
+ --r_75: #FFBDAD;
+ --r_100: #FF8F73;
+ --r_200: #FF7452;
+ --r_300: #FF5630;
+ --r_400: #DE350B;
+ --r_500: #BF2600;
+ --y_50: #FFFAE6;
+ --y_75: #FFF0B3;
+ --y_100: #FFE380;
+ --y_200: #FFC400;
+ --y_300: #FFAB00;
+ --y_400: #FF991F;
+ --y_500: #FF8B00;
+ --g_50: #E3FCEF;
+ --g_75: #ABF5D1;
+ --g_100: #79F2C0;
+ --g_200: #57D9A3;
+ --g_300: #36B37E;
+ --g_400: #00875A;
+ --g_500: #006644;
+ --b_50: #DEEBFF;
+ --b_75: #B3D4FF;
+ --b_100: #4C9AFF;
+ --b_200: #2684FF;
+ --b_300: #0065FF;
+ --b_400: #0052CC;
+ --b_500: #0747A6;
+ --p_50: #EAE6FF;
+ --p_75: #C0B6F2;
+ --p_100: #998DD9;
+ --p_200: #8777D9;
+ --p_300: #6554C0;
+ --p_400: #5243AA;
+ --p_500: #403294;
+ --t_50: #E6FCFF;
+ --t_75: #B3F5FF;
+ --t_100: #79E2F2;
+ --t_200: #00C7E6;
+ --t_300: #00B8D9;
+ --t_400: #00A3BF;
+ --t_500: #008DA6;
+ --n_0: #FFFFFF;
+ --n_10: #FAFBFC;
+ --n_20: #F4F5F7;
+ --n_30: #EBECF0;
+ --n_40: #DFE1E6;
+ --n_50: #C1C7D0;
+ --n_60: #B3BAC5;
+ --n_70: #A5ADBA;
+ --n_80: #97A0AF;
+ --n_90: #8993A4;
+ --n_100: #7A869A;
+ --n_200: #6B778C;
+ --n_300: #5E6C84;
+ --n_400: #505F79;
+ --n_500: #42526E;
+ --n_600: #344563;
+ --n_700: #253858;
+ --n_800: #172B4D;
+ --n_900: #091E42;
+ --n_10_a: rgba(9, 30, 66, 0.02);
+ --n_20_a: rgba(9, 30, 66, 0.04);
+ --n_30_a: rgba(9, 30, 66, 0.08);
+ --n_40_a: rgba(9, 30, 66, 0.13);
+ --n_50_a: rgba(9, 30, 66, 0.25);
+ --n_60_a: rgba(9, 30, 66, 0.31);
+ --n_70_a: rgba(9, 30, 66, 0.36);
+ --n_80_a: rgba(9, 30, 66, 0.42);
+ --n_90_a: rgba(9, 30, 66, 0.48);
+ --n_100_a: rgba(9, 30, 66, 0.54);
+ --n_200_a: rgba(9, 30, 66, 0.60);
+ --n_300_a: rgba(9, 30, 66, 0.66);
+ --n_400_a: rgba(9, 30, 66, 0.71);
+ --n_500_a: rgba(9, 30, 66, 0.77);
+ --n_600_a: rgba(9, 30, 66, 0.82);
+ --n_700_a: rgba(9, 30, 66, 0.89);
+ --n_800_a: rgba(9, 30, 66, 0.95);
+ --dn_900: #E6EDFA;
+ --dn_800: #DCE5F5;
+ --dn_700: #CED9EB;
+ --dn_600: #B8C7E0;
+ --dn_500: #ABBBD6;
+ --dn_400: #9FB0CC;
+ --dn_300: #8C9CB8;
+ --dn_200: #7988A3;
+ --dn_100: #67758F;
+ --dn_90: #56637A;
+ --dn_80: #455166;
+ --dn_70: #3B475C;
+ --dn_60: #313D52;
+ --dn_50: #283447;
+ --dn_40: #202B3D;
+ --dn_30: #1B2638;
+ --dn_20: #121A29;
+ --dn_10: #0E1624;
+ --dn_0: #0D1424;
+ --dn_800_a: rgba(13, 20, 36, 0.06);
+ --dn_700_a: rgba(13, 20, 36, 0.14);
+ --dn_600_a: rgba(13, 20, 36, 0.18);
+ --dn_500_a: rgba(13, 20, 36, 0.29);
+ --dn_400_a: rgba(13, 20, 36, 0.36);
+ --dn_300_a: rgba(13, 20, 36, 0.40);
+ --dn_200_a: rgba(13, 20, 36, 0.47);
+ --dn_100_a: rgba(13, 20, 36, 0.53);
+ --dn_90_a: rgba(13, 20, 36, 0.63);
+ --dn_80_a: rgba(13, 20, 36, 0.73);
+ --dn_70_a: rgba(13, 20, 36, 0.78);
+ --dn_60_a: rgba(13, 20, 36, 0.81);
+ --dn_50_a: rgba(13, 20, 36, 0.85);
+ --dn_40_a: rgba(13, 20, 36, 0.89);
+ --dn_30_a: rgba(13, 20, 36, 0.92);
+ --dn_20_a: rgba(13, 20, 36, 0.95);
+ --dn_10_a: rgba(13, 20, 36, 0.97);
+ --layer_100: 100;
+ --layer_300: 300;
+ --layer_200: 200;
+ --layer_400: 400;
+ --layer_500: 500;
+ --layer_510: 510;
+ --layer_600: 600;
+ --layer_700: 700;
+ --layer_800: 800;
+ --grid_0_25_x: 2;
+ --grid_0_5_x: 4;
+ --grid_1_x: 8;
+ --messaging_colors_text_normal_resting: #42526E;
+ --messaging_colors_text_normal_highlight: #344563;
+ --messaging_colors_text_bold_resting: #FFFFFF;
+}
+"
+`;
+
+exports[`on yarn build output files should match snapshots css 3`] = `
+"
+
+:root {
+ --layer_100: 100;
+ --layer_300: 300;
+ --layer_200: 200;
+ --layer_400: 400;
+ --layer_500: 500;
+ --layer_510: 510;
+ --layer_600: 600;
+ --layer_700: 700;
+ --layer_800: 800;
+}
+"
+`;
+
+exports[`on yarn build output files should match snapshots css 4`] = `
+"
+
+:root {
+ --messaging_colors_text_normal_resting: #42526E;
+ --messaging_colors_text_normal_highlight: #344563;
+ --messaging_colors_text_bold_resting: #FFFFFF;
+}
+"
+`;
+
+exports[`on yarn build output files should match snapshots css 5`] = `
+"
+
+:root {
+ --grid_0_25_x: 2;
+ --grid_0_5_x: 4;
+ --grid_1_x: 8;
+}
+"
+`;
+
+exports[`on yarn build output files should match snapshots js 1`] = `
+"
+
+export const  R50 = \\"#FFEBE6\\";
+export const  R75 = \\"#FFBDAD\\";
+export const  R100 = \\"#FF8F73\\";
+export const  R200 = \\"#FF7452\\";
+export const  R300 = \\"#FF5630\\";
+export const  R400 = \\"#DE350B\\";
+export const  R500 = \\"#BF2600\\";
+export const  Y50 = \\"#FFFAE6\\";
+export const  Y75 = \\"#FFF0B3\\";
+export const  Y100 = \\"#FFE380\\";
+export const  Y200 = \\"#FFC400\\";
+export const  Y300 = \\"#FFAB00\\";
+export const  Y400 = \\"#FF991F\\";
+export const  Y500 = \\"#FF8B00\\";
+export const  G50 = \\"#E3FCEF\\";
+export const  G75 = \\"#ABF5D1\\";
+export const  G100 = \\"#79F2C0\\";
+export const  G200 = \\"#57D9A3\\";
+export const  G300 = \\"#36B37E\\";
+export const  G400 = \\"#00875A\\";
+export const  G500 = \\"#006644\\";
+export const  B50 = \\"#DEEBFF\\";
+export const  B75 = \\"#B3D4FF\\";
+export const  B100 = \\"#4C9AFF\\";
+export const  B200 = \\"#2684FF\\";
+export const  B300 = \\"#0065FF\\";
+export const  B400 = \\"#0052CC\\";
+export const  B500 = \\"#0747A6\\";
+export const  P50 = \\"#EAE6FF\\";
+export const  P75 = \\"#C0B6F2\\";
+export const  P100 = \\"#998DD9\\";
+export const  P200 = \\"#8777D9\\";
+export const  P300 = \\"#6554C0\\";
+export const  P400 = \\"#5243AA\\";
+export const  P500 = \\"#403294\\";
+export const  T50 = \\"#E6FCFF\\";
+export const  T75 = \\"#B3F5FF\\";
+export const  T100 = \\"#79E2F2\\";
+export const  T200 = \\"#00C7E6\\";
+export const  T300 = \\"#00B8D9\\";
+export const  T400 = \\"#00A3BF\\";
+export const  T500 = \\"#008DA6\\";
+export const  N0 = \\"#FFFFFF\\";
+export const  N10 = \\"#FAFBFC\\";
+export const  N20 = \\"#F4F5F7\\";
+export const  N30 = \\"#EBECF0\\";
+export const  N40 = \\"#DFE1E6\\";
+export const  N50 = \\"#C1C7D0\\";
+export const  N60 = \\"#B3BAC5\\";
+export const  N70 = \\"#A5ADBA\\";
+export const  N80 = \\"#97A0AF\\";
+export const  N90 = \\"#8993A4\\";
+export const  N100 = \\"#7A869A\\";
+export const  N200 = \\"#6B778C\\";
+export const  N300 = \\"#5E6C84\\";
+export const  N400 = \\"#505F79\\";
+export const  N500 = \\"#42526E\\";
+export const  N600 = \\"#344563\\";
+export const  N700 = \\"#253858\\";
+export const  N800 = \\"#172B4D\\";
+export const  N900 = \\"#091E42\\";
+export const  N10A = \\"rgba(9, 30, 66, 0.02)\\";
+export const  N20A = \\"rgba(9, 30, 66, 0.04)\\";
+export const  N30A = \\"rgba(9, 30, 66, 0.08)\\";
+export const  N40A = \\"rgba(9, 30, 66, 0.13)\\";
+export const  N50A = \\"rgba(9, 30, 66, 0.25)\\";
+export const  N60A = \\"rgba(9, 30, 66, 0.31)\\";
+export const  N70A = \\"rgba(9, 30, 66, 0.36)\\";
+export const  N80A = \\"rgba(9, 30, 66, 0.42)\\";
+export const  N90A = \\"rgba(9, 30, 66, 0.48)\\";
+export const  N100A = \\"rgba(9, 30, 66, 0.54)\\";
+export const  N200A = \\"rgba(9, 30, 66, 0.60)\\";
+export const  N300A = \\"rgba(9, 30, 66, 0.66)\\";
+export const  N400A = \\"rgba(9, 30, 66, 0.71)\\";
+export const  N500A = \\"rgba(9, 30, 66, 0.77)\\";
+export const  N600A = \\"rgba(9, 30, 66, 0.82)\\";
+export const  N700A = \\"rgba(9, 30, 66, 0.89)\\";
+export const  N800A = \\"rgba(9, 30, 66, 0.95)\\";
+export const  DN900 = \\"#E6EDFA\\";
+export const  DN800 = \\"#DCE5F5\\";
+export const  DN700 = \\"#CED9EB\\";
+export const  DN600 = \\"#B8C7E0\\";
+export const  DN500 = \\"#ABBBD6\\";
+export const  DN400 = \\"#9FB0CC\\";
+export const  DN300 = \\"#8C9CB8\\";
+export const  DN200 = \\"#7988A3\\";
+export const  DN100 = \\"#67758F\\";
+export const  DN90 = \\"#56637A\\";
+export const  DN80 = \\"#455166\\";
+export const  DN70 = \\"#3B475C\\";
+export const  DN60 = \\"#313D52\\";
+export const  DN50 = \\"#283447\\";
+export const  DN40 = \\"#202B3D\\";
+export const  DN30 = \\"#1B2638\\";
+export const  DN20 = \\"#121A29\\";
+export const  DN10 = \\"#0E1624\\";
+export const  DN0 = \\"#0D1424\\";
+export const  DN800A = \\"rgba(13, 20, 36, 0.06)\\";
+export const  DN700A = \\"rgba(13, 20, 36, 0.14)\\";
+export const  DN600A = \\"rgba(13, 20, 36, 0.18)\\";
+export const  DN500A = \\"rgba(13, 20, 36, 0.29)\\";
+export const  DN400A = \\"rgba(13, 20, 36, 0.36)\\";
+export const  DN300A = \\"rgba(13, 20, 36, 0.40)\\";
+export const  DN200A = \\"rgba(13, 20, 36, 0.47)\\";
+export const  DN100A = \\"rgba(13, 20, 36, 0.53)\\";
+export const  DN90A = \\"rgba(13, 20, 36, 0.63)\\";
+export const  DN80A = \\"rgba(13, 20, 36, 0.73)\\";
+export const  DN70A = \\"rgba(13, 20, 36, 0.78)\\";
+export const  DN60A = \\"rgba(13, 20, 36, 0.81)\\";
+export const  DN50A = \\"rgba(13, 20, 36, 0.85)\\";
+export const  DN40A = \\"rgba(13, 20, 36, 0.89)\\";
+export const  DN30A = \\"rgba(13, 20, 36, 0.92)\\";
+export const  DN20A = \\"rgba(13, 20, 36, 0.95)\\";
+export const  DN10A = \\"rgba(13, 20, 36, 0.97)\\";"
+`;
+
+exports[`on yarn build output files should match snapshots js 2`] = `
+"
+
+export const  R50 = \\"#FFEBE6\\";
+export const  R75 = \\"#FFBDAD\\";
+export const  R100 = \\"#FF8F73\\";
+export const  R200 = \\"#FF7452\\";
+export const  R300 = \\"#FF5630\\";
+export const  R400 = \\"#DE350B\\";
+export const  R500 = \\"#BF2600\\";
+export const  Y50 = \\"#FFFAE6\\";
+export const  Y75 = \\"#FFF0B3\\";
+export const  Y100 = \\"#FFE380\\";
+export const  Y200 = \\"#FFC400\\";
+export const  Y300 = \\"#FFAB00\\";
+export const  Y400 = \\"#FF991F\\";
+export const  Y500 = \\"#FF8B00\\";
+export const  G50 = \\"#E3FCEF\\";
+export const  G75 = \\"#ABF5D1\\";
+export const  G100 = \\"#79F2C0\\";
+export const  G200 = \\"#57D9A3\\";
+export const  G300 = \\"#36B37E\\";
+export const  G400 = \\"#00875A\\";
+export const  G500 = \\"#006644\\";
+export const  B50 = \\"#DEEBFF\\";
+export const  B75 = \\"#B3D4FF\\";
+export const  B100 = \\"#4C9AFF\\";
+export const  B200 = \\"#2684FF\\";
+export const  B300 = \\"#0065FF\\";
+export const  B400 = \\"#0052CC\\";
+export const  B500 = \\"#0747A6\\";
+export const  P50 = \\"#EAE6FF\\";
+export const  P75 = \\"#C0B6F2\\";
+export const  P100 = \\"#998DD9\\";
+export const  P200 = \\"#8777D9\\";
+export const  P300 = \\"#6554C0\\";
+export const  P400 = \\"#5243AA\\";
+export const  P500 = \\"#403294\\";
+export const  T50 = \\"#E6FCFF\\";
+export const  T75 = \\"#B3F5FF\\";
+export const  T100 = \\"#79E2F2\\";
+export const  T200 = \\"#00C7E6\\";
+export const  T300 = \\"#00B8D9\\";
+export const  T400 = \\"#00A3BF\\";
+export const  T500 = \\"#008DA6\\";
+export const  N0 = \\"#FFFFFF\\";
+export const  N10 = \\"#FAFBFC\\";
+export const  N20 = \\"#F4F5F7\\";
+export const  N30 = \\"#EBECF0\\";
+export const  N40 = \\"#DFE1E6\\";
+export const  N50 = \\"#C1C7D0\\";
+export const  N60 = \\"#B3BAC5\\";
+export const  N70 = \\"#A5ADBA\\";
+export const  N80 = \\"#97A0AF\\";
+export const  N90 = \\"#8993A4\\";
+export const  N100 = \\"#7A869A\\";
+export const  N200 = \\"#6B778C\\";
+export const  N300 = \\"#5E6C84\\";
+export const  N400 = \\"#505F79\\";
+export const  N500 = \\"#42526E\\";
+export const  N600 = \\"#344563\\";
+export const  N700 = \\"#253858\\";
+export const  N800 = \\"#172B4D\\";
+export const  N900 = \\"#091E42\\";
+export const  N10A = \\"rgba(9, 30, 66, 0.02)\\";
+export const  N20A = \\"rgba(9, 30, 66, 0.04)\\";
+export const  N30A = \\"rgba(9, 30, 66, 0.08)\\";
+export const  N40A = \\"rgba(9, 30, 66, 0.13)\\";
+export const  N50A = \\"rgba(9, 30, 66, 0.25)\\";
+export const  N60A = \\"rgba(9, 30, 66, 0.31)\\";
+export const  N70A = \\"rgba(9, 30, 66, 0.36)\\";
+export const  N80A = \\"rgba(9, 30, 66, 0.42)\\";
+export const  N90A = \\"rgba(9, 30, 66, 0.48)\\";
+export const  N100A = \\"rgba(9, 30, 66, 0.54)\\";
+export const  N200A = \\"rgba(9, 30, 66, 0.60)\\";
+export const  N300A = \\"rgba(9, 30, 66, 0.66)\\";
+export const  N400A = \\"rgba(9, 30, 66, 0.71)\\";
+export const  N500A = \\"rgba(9, 30, 66, 0.77)\\";
+export const  N600A = \\"rgba(9, 30, 66, 0.82)\\";
+export const  N700A = \\"rgba(9, 30, 66, 0.89)\\";
+export const  N800A = \\"rgba(9, 30, 66, 0.95)\\";
+export const  DN900 = \\"#E6EDFA\\";
+export const  DN800 = \\"#DCE5F5\\";
+export const  DN700 = \\"#CED9EB\\";
+export const  DN600 = \\"#B8C7E0\\";
+export const  DN500 = \\"#ABBBD6\\";
+export const  DN400 = \\"#9FB0CC\\";
+export const  DN300 = \\"#8C9CB8\\";
+export const  DN200 = \\"#7988A3\\";
+export const  DN100 = \\"#67758F\\";
+export const  DN90 = \\"#56637A\\";
+export const  DN80 = \\"#455166\\";
+export const  DN70 = \\"#3B475C\\";
+export const  DN60 = \\"#313D52\\";
+export const  DN50 = \\"#283447\\";
+export const  DN40 = \\"#202B3D\\";
+export const  DN30 = \\"#1B2638\\";
+export const  DN20 = \\"#121A29\\";
+export const  DN10 = \\"#0E1624\\";
+export const  DN0 = \\"#0D1424\\";
+export const  DN800A = \\"rgba(13, 20, 36, 0.06)\\";
+export const  DN700A = \\"rgba(13, 20, 36, 0.14)\\";
+export const  DN600A = \\"rgba(13, 20, 36, 0.18)\\";
+export const  DN500A = \\"rgba(13, 20, 36, 0.29)\\";
+export const  DN400A = \\"rgba(13, 20, 36, 0.36)\\";
+export const  DN300A = \\"rgba(13, 20, 36, 0.40)\\";
+export const  DN200A = \\"rgba(13, 20, 36, 0.47)\\";
+export const  DN100A = \\"rgba(13, 20, 36, 0.53)\\";
+export const  DN90A = \\"rgba(13, 20, 36, 0.63)\\";
+export const  DN80A = \\"rgba(13, 20, 36, 0.73)\\";
+export const  DN70A = \\"rgba(13, 20, 36, 0.78)\\";
+export const  DN60A = \\"rgba(13, 20, 36, 0.81)\\";
+export const  DN50A = \\"rgba(13, 20, 36, 0.85)\\";
+export const  DN40A = \\"rgba(13, 20, 36, 0.89)\\";
+export const  DN30A = \\"rgba(13, 20, 36, 0.92)\\";
+export const  DN20A = \\"rgba(13, 20, 36, 0.95)\\";
+export const  DN10A = \\"rgba(13, 20, 36, 0.97)\\";
+export const layer100 = 100;
+export const layer300 = 300;
+export const layer200 = 200;
+export const layer400 = 400;
+export const layer500 = 500;
+export const layer510 = 510;
+export const layer600 = 600;
+export const layer700 = 700;
+export const layer800 = 800;
+export const grid025X = 2;
+export const grid05X = 4;
+export const grid1X = 8;
+export const messagingColorsTextNormalResting = \\"#42526E\\";
+export const messagingColorsTextNormalHighlight = \\"#344563\\";
+export const messagingColorsTextBoldResting = \\"#FFFFFF\\";"
+`;
+
+exports[`on yarn build output files should match snapshots js 3`] = `
+"
+
+export const messagingColorsTextNormalResting = \\"#42526E\\";
+export const messagingColorsTextNormalHighlight = \\"#344563\\";
+export const messagingColorsTextBoldResting = \\"#FFFFFF\\";"
+`;
+
+exports[`on yarn build output files should match snapshots js 4`] = `
+"
+
+export const layer100 = 100;
+export const layer300 = 300;
+export const layer200 = 200;
+export const layer400 = 400;
+export const layer500 = 500;
+export const layer510 = 510;
+export const layer600 = 600;
+export const layer700 = 700;
+export const layer800 = 800;"
+`;
+
+exports[`on yarn build output files should match snapshots js 5`] = `
+"
+
+export const grid025X = 2;
+export const grid05X = 4;
+export const grid1X = 8;"
+`;
+
+exports[`on yarn build output files should match snapshots json 1`] = `
+"{
+  \\"r_50\\": \\"#FFEBE6\\",
+  \\"r_75\\": \\"#FFBDAD\\",
+  \\"r_100\\": \\"#FF8F73\\",
+  \\"r_200\\": \\"#FF7452\\",
+  \\"r_300\\": \\"#FF5630\\",
+  \\"r_400\\": \\"#DE350B\\",
+  \\"r_500\\": \\"#BF2600\\",
+  \\"y_50\\": \\"#FFFAE6\\",
+  \\"y_75\\": \\"#FFF0B3\\",
+  \\"y_100\\": \\"#FFE380\\",
+  \\"y_200\\": \\"#FFC400\\",
+  \\"y_300\\": \\"#FFAB00\\",
+  \\"y_400\\": \\"#FF991F\\",
+  \\"y_500\\": \\"#FF8B00\\",
+  \\"g_50\\": \\"#E3FCEF\\",
+  \\"g_75\\": \\"#ABF5D1\\",
+  \\"g_100\\": \\"#79F2C0\\",
+  \\"g_200\\": \\"#57D9A3\\",
+  \\"g_300\\": \\"#36B37E\\",
+  \\"g_400\\": \\"#00875A\\",
+  \\"g_500\\": \\"#006644\\",
+  \\"b_50\\": \\"#DEEBFF\\",
+  \\"b_75\\": \\"#B3D4FF\\",
+  \\"b_100\\": \\"#4C9AFF\\",
+  \\"b_200\\": \\"#2684FF\\",
+  \\"b_300\\": \\"#0065FF\\",
+  \\"b_400\\": \\"#0052CC\\",
+  \\"b_500\\": \\"#0747A6\\",
+  \\"p_50\\": \\"#EAE6FF\\",
+  \\"p_75\\": \\"#C0B6F2\\",
+  \\"p_100\\": \\"#998DD9\\",
+  \\"p_200\\": \\"#8777D9\\",
+  \\"p_300\\": \\"#6554C0\\",
+  \\"p_400\\": \\"#5243AA\\",
+  \\"p_500\\": \\"#403294\\",
+  \\"t_50\\": \\"#E6FCFF\\",
+  \\"t_75\\": \\"#B3F5FF\\",
+  \\"t_100\\": \\"#79E2F2\\",
+  \\"t_200\\": \\"#00C7E6\\",
+  \\"t_300\\": \\"#00B8D9\\",
+  \\"t_400\\": \\"#00A3BF\\",
+  \\"t_500\\": \\"#008DA6\\",
+  \\"n_0\\": \\"#FFFFFF\\",
+  \\"n_10\\": \\"#FAFBFC\\",
+  \\"n_20\\": \\"#F4F5F7\\",
+  \\"n_30\\": \\"#EBECF0\\",
+  \\"n_40\\": \\"#DFE1E6\\",
+  \\"n_50\\": \\"#C1C7D0\\",
+  \\"n_60\\": \\"#B3BAC5\\",
+  \\"n_70\\": \\"#A5ADBA\\",
+  \\"n_80\\": \\"#97A0AF\\",
+  \\"n_90\\": \\"#8993A4\\",
+  \\"n_100\\": \\"#7A869A\\",
+  \\"n_200\\": \\"#6B778C\\",
+  \\"n_300\\": \\"#5E6C84\\",
+  \\"n_400\\": \\"#505F79\\",
+  \\"n_500\\": \\"#42526E\\",
+  \\"n_600\\": \\"#344563\\",
+  \\"n_700\\": \\"#253858\\",
+  \\"n_800\\": \\"#172B4D\\",
+  \\"n_900\\": \\"#091E42\\",
+  \\"n_10_a\\": \\"rgba(9, 30, 66, 0.02)\\",
+  \\"n_20_a\\": \\"rgba(9, 30, 66, 0.04)\\",
+  \\"n_30_a\\": \\"rgba(9, 30, 66, 0.08)\\",
+  \\"n_40_a\\": \\"rgba(9, 30, 66, 0.13)\\",
+  \\"n_50_a\\": \\"rgba(9, 30, 66, 0.25)\\",
+  \\"n_60_a\\": \\"rgba(9, 30, 66, 0.31)\\",
+  \\"n_70_a\\": \\"rgba(9, 30, 66, 0.36)\\",
+  \\"n_80_a\\": \\"rgba(9, 30, 66, 0.42)\\",
+  \\"n_90_a\\": \\"rgba(9, 30, 66, 0.48)\\",
+  \\"n_100_a\\": \\"rgba(9, 30, 66, 0.54)\\",
+  \\"n_200_a\\": \\"rgba(9, 30, 66, 0.60)\\",
+  \\"n_300_a\\": \\"rgba(9, 30, 66, 0.66)\\",
+  \\"n_400_a\\": \\"rgba(9, 30, 66, 0.71)\\",
+  \\"n_500_a\\": \\"rgba(9, 30, 66, 0.77)\\",
+  \\"n_600_a\\": \\"rgba(9, 30, 66, 0.82)\\",
+  \\"n_700_a\\": \\"rgba(9, 30, 66, 0.89)\\",
+  \\"n_800_a\\": \\"rgba(9, 30, 66, 0.95)\\",
+  \\"dn_900\\": \\"#E6EDFA\\",
+  \\"dn_800\\": \\"#DCE5F5\\",
+  \\"dn_700\\": \\"#CED9EB\\",
+  \\"dn_600\\": \\"#B8C7E0\\",
+  \\"dn_500\\": \\"#ABBBD6\\",
+  \\"dn_400\\": \\"#9FB0CC\\",
+  \\"dn_300\\": \\"#8C9CB8\\",
+  \\"dn_200\\": \\"#7988A3\\",
+  \\"dn_100\\": \\"#67758F\\",
+  \\"dn_90\\": \\"#56637A\\",
+  \\"dn_80\\": \\"#455166\\",
+  \\"dn_70\\": \\"#3B475C\\",
+  \\"dn_60\\": \\"#313D52\\",
+  \\"dn_50\\": \\"#283447\\",
+  \\"dn_40\\": \\"#202B3D\\",
+  \\"dn_30\\": \\"#1B2638\\",
+  \\"dn_20\\": \\"#121A29\\",
+  \\"dn_10\\": \\"#0E1624\\",
+  \\"dn_0\\": \\"#0D1424\\",
+  \\"dn_800_a\\": \\"rgba(13, 20, 36, 0.06)\\",
+  \\"dn_700_a\\": \\"rgba(13, 20, 36, 0.14)\\",
+  \\"dn_600_a\\": \\"rgba(13, 20, 36, 0.18)\\",
+  \\"dn_500_a\\": \\"rgba(13, 20, 36, 0.29)\\",
+  \\"dn_400_a\\": \\"rgba(13, 20, 36, 0.36)\\",
+  \\"dn_300_a\\": \\"rgba(13, 20, 36, 0.40)\\",
+  \\"dn_200_a\\": \\"rgba(13, 20, 36, 0.47)\\",
+  \\"dn_100_a\\": \\"rgba(13, 20, 36, 0.53)\\",
+  \\"dn_90_a\\": \\"rgba(13, 20, 36, 0.63)\\",
+  \\"dn_80_a\\": \\"rgba(13, 20, 36, 0.73)\\",
+  \\"dn_70_a\\": \\"rgba(13, 20, 36, 0.78)\\",
+  \\"dn_60_a\\": \\"rgba(13, 20, 36, 0.81)\\",
+  \\"dn_50_a\\": \\"rgba(13, 20, 36, 0.85)\\",
+  \\"dn_40_a\\": \\"rgba(13, 20, 36, 0.89)\\",
+  \\"dn_30_a\\": \\"rgba(13, 20, 36, 0.92)\\",
+  \\"dn_20_a\\": \\"rgba(13, 20, 36, 0.95)\\",
+  \\"dn_10_a\\": \\"rgba(13, 20, 36, 0.97)\\"
+}"
+`;
+
+exports[`on yarn build output files should match snapshots json 2`] = `
+"{
+  \\"r_50\\": \\"#FFEBE6\\",
+  \\"r_75\\": \\"#FFBDAD\\",
+  \\"r_100\\": \\"#FF8F73\\",
+  \\"r_200\\": \\"#FF7452\\",
+  \\"r_300\\": \\"#FF5630\\",
+  \\"r_400\\": \\"#DE350B\\",
+  \\"r_500\\": \\"#BF2600\\",
+  \\"y_50\\": \\"#FFFAE6\\",
+  \\"y_75\\": \\"#FFF0B3\\",
+  \\"y_100\\": \\"#FFE380\\",
+  \\"y_200\\": \\"#FFC400\\",
+  \\"y_300\\": \\"#FFAB00\\",
+  \\"y_400\\": \\"#FF991F\\",
+  \\"y_500\\": \\"#FF8B00\\",
+  \\"g_50\\": \\"#E3FCEF\\",
+  \\"g_75\\": \\"#ABF5D1\\",
+  \\"g_100\\": \\"#79F2C0\\",
+  \\"g_200\\": \\"#57D9A3\\",
+  \\"g_300\\": \\"#36B37E\\",
+  \\"g_400\\": \\"#00875A\\",
+  \\"g_500\\": \\"#006644\\",
+  \\"b_50\\": \\"#DEEBFF\\",
+  \\"b_75\\": \\"#B3D4FF\\",
+  \\"b_100\\": \\"#4C9AFF\\",
+  \\"b_200\\": \\"#2684FF\\",
+  \\"b_300\\": \\"#0065FF\\",
+  \\"b_400\\": \\"#0052CC\\",
+  \\"b_500\\": \\"#0747A6\\",
+  \\"p_50\\": \\"#EAE6FF\\",
+  \\"p_75\\": \\"#C0B6F2\\",
+  \\"p_100\\": \\"#998DD9\\",
+  \\"p_200\\": \\"#8777D9\\",
+  \\"p_300\\": \\"#6554C0\\",
+  \\"p_400\\": \\"#5243AA\\",
+  \\"p_500\\": \\"#403294\\",
+  \\"t_50\\": \\"#E6FCFF\\",
+  \\"t_75\\": \\"#B3F5FF\\",
+  \\"t_100\\": \\"#79E2F2\\",
+  \\"t_200\\": \\"#00C7E6\\",
+  \\"t_300\\": \\"#00B8D9\\",
+  \\"t_400\\": \\"#00A3BF\\",
+  \\"t_500\\": \\"#008DA6\\",
+  \\"n_0\\": \\"#FFFFFF\\",
+  \\"n_10\\": \\"#FAFBFC\\",
+  \\"n_20\\": \\"#F4F5F7\\",
+  \\"n_30\\": \\"#EBECF0\\",
+  \\"n_40\\": \\"#DFE1E6\\",
+  \\"n_50\\": \\"#C1C7D0\\",
+  \\"n_60\\": \\"#B3BAC5\\",
+  \\"n_70\\": \\"#A5ADBA\\",
+  \\"n_80\\": \\"#97A0AF\\",
+  \\"n_90\\": \\"#8993A4\\",
+  \\"n_100\\": \\"#7A869A\\",
+  \\"n_200\\": \\"#6B778C\\",
+  \\"n_300\\": \\"#5E6C84\\",
+  \\"n_400\\": \\"#505F79\\",
+  \\"n_500\\": \\"#42526E\\",
+  \\"n_600\\": \\"#344563\\",
+  \\"n_700\\": \\"#253858\\",
+  \\"n_800\\": \\"#172B4D\\",
+  \\"n_900\\": \\"#091E42\\",
+  \\"n_10_a\\": \\"rgba(9, 30, 66, 0.02)\\",
+  \\"n_20_a\\": \\"rgba(9, 30, 66, 0.04)\\",
+  \\"n_30_a\\": \\"rgba(9, 30, 66, 0.08)\\",
+  \\"n_40_a\\": \\"rgba(9, 30, 66, 0.13)\\",
+  \\"n_50_a\\": \\"rgba(9, 30, 66, 0.25)\\",
+  \\"n_60_a\\": \\"rgba(9, 30, 66, 0.31)\\",
+  \\"n_70_a\\": \\"rgba(9, 30, 66, 0.36)\\",
+  \\"n_80_a\\": \\"rgba(9, 30, 66, 0.42)\\",
+  \\"n_90_a\\": \\"rgba(9, 30, 66, 0.48)\\",
+  \\"n_100_a\\": \\"rgba(9, 30, 66, 0.54)\\",
+  \\"n_200_a\\": \\"rgba(9, 30, 66, 0.60)\\",
+  \\"n_300_a\\": \\"rgba(9, 30, 66, 0.66)\\",
+  \\"n_400_a\\": \\"rgba(9, 30, 66, 0.71)\\",
+  \\"n_500_a\\": \\"rgba(9, 30, 66, 0.77)\\",
+  \\"n_600_a\\": \\"rgba(9, 30, 66, 0.82)\\",
+  \\"n_700_a\\": \\"rgba(9, 30, 66, 0.89)\\",
+  \\"n_800_a\\": \\"rgba(9, 30, 66, 0.95)\\",
+  \\"dn_900\\": \\"#E6EDFA\\",
+  \\"dn_800\\": \\"#DCE5F5\\",
+  \\"dn_700\\": \\"#CED9EB\\",
+  \\"dn_600\\": \\"#B8C7E0\\",
+  \\"dn_500\\": \\"#ABBBD6\\",
+  \\"dn_400\\": \\"#9FB0CC\\",
+  \\"dn_300\\": \\"#8C9CB8\\",
+  \\"dn_200\\": \\"#7988A3\\",
+  \\"dn_100\\": \\"#67758F\\",
+  \\"dn_90\\": \\"#56637A\\",
+  \\"dn_80\\": \\"#455166\\",
+  \\"dn_70\\": \\"#3B475C\\",
+  \\"dn_60\\": \\"#313D52\\",
+  \\"dn_50\\": \\"#283447\\",
+  \\"dn_40\\": \\"#202B3D\\",
+  \\"dn_30\\": \\"#1B2638\\",
+  \\"dn_20\\": \\"#121A29\\",
+  \\"dn_10\\": \\"#0E1624\\",
+  \\"dn_0\\": \\"#0D1424\\",
+  \\"dn_800_a\\": \\"rgba(13, 20, 36, 0.06)\\",
+  \\"dn_700_a\\": \\"rgba(13, 20, 36, 0.14)\\",
+  \\"dn_600_a\\": \\"rgba(13, 20, 36, 0.18)\\",
+  \\"dn_500_a\\": \\"rgba(13, 20, 36, 0.29)\\",
+  \\"dn_400_a\\": \\"rgba(13, 20, 36, 0.36)\\",
+  \\"dn_300_a\\": \\"rgba(13, 20, 36, 0.40)\\",
+  \\"dn_200_a\\": \\"rgba(13, 20, 36, 0.47)\\",
+  \\"dn_100_a\\": \\"rgba(13, 20, 36, 0.53)\\",
+  \\"dn_90_a\\": \\"rgba(13, 20, 36, 0.63)\\",
+  \\"dn_80_a\\": \\"rgba(13, 20, 36, 0.73)\\",
+  \\"dn_70_a\\": \\"rgba(13, 20, 36, 0.78)\\",
+  \\"dn_60_a\\": \\"rgba(13, 20, 36, 0.81)\\",
+  \\"dn_50_a\\": \\"rgba(13, 20, 36, 0.85)\\",
+  \\"dn_40_a\\": \\"rgba(13, 20, 36, 0.89)\\",
+  \\"dn_30_a\\": \\"rgba(13, 20, 36, 0.92)\\",
+  \\"dn_20_a\\": \\"rgba(13, 20, 36, 0.95)\\",
+  \\"dn_10_a\\": \\"rgba(13, 20, 36, 0.97)\\",
+  \\"layer_100\\": 100,
+  \\"layer_300\\": 300,
+  \\"layer_200\\": 200,
+  \\"layer_400\\": 400,
+  \\"layer_500\\": 500,
+  \\"layer_510\\": 510,
+  \\"layer_600\\": 600,
+  \\"layer_700\\": 700,
+  \\"layer_800\\": 800,
+  \\"grid_0_25_x\\": 2,
+  \\"grid_0_5_x\\": 4,
+  \\"grid_1_x\\": 8,
+  \\"messaging_colors_text_normal_resting\\": \\"#42526E\\",
+  \\"messaging_colors_text_normal_highlight\\": \\"#344563\\",
+  \\"messaging_colors_text_bold_resting\\": \\"#FFFFFF\\"
+}"
+`;
+
+exports[`on yarn build output files should match snapshots json 3`] = `
+"{
+  \\"layer_100\\": 100,
+  \\"layer_300\\": 300,
+  \\"layer_200\\": 200,
+  \\"layer_400\\": 400,
+  \\"layer_500\\": 500,
+  \\"layer_510\\": 510,
+  \\"layer_600\\": 600,
+  \\"layer_700\\": 700,
+  \\"layer_800\\": 800
+}"
+`;
+
+exports[`on yarn build output files should match snapshots json 4`] = `
+"{
+  \\"messaging_colors_text_normal_resting\\": \\"#42526E\\",
+  \\"messaging_colors_text_normal_highlight\\": \\"#344563\\",
+  \\"messaging_colors_text_bold_resting\\": \\"#FFFFFF\\"
+}"
+`;
+
+exports[`on yarn build output files should match snapshots json 5`] = `
+"{
+  \\"grid_0_25_x\\": 2,
+  \\"grid_0_5_x\\": 4,
+  \\"grid_1_x\\": 8
+}"
+`;
+
+exports[`on yarn build output files should match snapshots less 1`] = `
+"
+
+@r_50: #FFEBE6;
+@r_75: #FFBDAD;
+@r_100: #FF8F73;
+@r_200: #FF7452;
+@r_300: #FF5630;
+@r_400: #DE350B;
+@r_500: #BF2600;
+@y_50: #FFFAE6;
+@y_75: #FFF0B3;
+@y_100: #FFE380;
+@y_200: #FFC400;
+@y_300: #FFAB00;
+@y_400: #FF991F;
+@y_500: #FF8B00;
+@g_50: #E3FCEF;
+@g_75: #ABF5D1;
+@g_100: #79F2C0;
+@g_200: #57D9A3;
+@g_300: #36B37E;
+@g_400: #00875A;
+@g_500: #006644;
+@b_50: #DEEBFF;
+@b_75: #B3D4FF;
+@b_100: #4C9AFF;
+@b_200: #2684FF;
+@b_300: #0065FF;
+@b_400: #0052CC;
+@b_500: #0747A6;
+@p_50: #EAE6FF;
+@p_75: #C0B6F2;
+@p_100: #998DD9;
+@p_200: #8777D9;
+@p_300: #6554C0;
+@p_400: #5243AA;
+@p_500: #403294;
+@t_50: #E6FCFF;
+@t_75: #B3F5FF;
+@t_100: #79E2F2;
+@t_200: #00C7E6;
+@t_300: #00B8D9;
+@t_400: #00A3BF;
+@t_500: #008DA6;
+@n_0: #FFFFFF;
+@n_10: #FAFBFC;
+@n_20: #F4F5F7;
+@n_30: #EBECF0;
+@n_40: #DFE1E6;
+@n_50: #C1C7D0;
+@n_60: #B3BAC5;
+@n_70: #A5ADBA;
+@n_80: #97A0AF;
+@n_90: #8993A4;
+@n_100: #7A869A;
+@n_200: #6B778C;
+@n_300: #5E6C84;
+@n_400: #505F79;
+@n_500: #42526E;
+@n_600: #344563;
+@n_700: #253858;
+@n_800: #172B4D;
+@n_900: #091E42;
+@n_10_a: rgba(9, 30, 66, 0.02);
+@n_20_a: rgba(9, 30, 66, 0.04);
+@n_30_a: rgba(9, 30, 66, 0.08);
+@n_40_a: rgba(9, 30, 66, 0.13);
+@n_50_a: rgba(9, 30, 66, 0.25);
+@n_60_a: rgba(9, 30, 66, 0.31);
+@n_70_a: rgba(9, 30, 66, 0.36);
+@n_80_a: rgba(9, 30, 66, 0.42);
+@n_90_a: rgba(9, 30, 66, 0.48);
+@n_100_a: rgba(9, 30, 66, 0.54);
+@n_200_a: rgba(9, 30, 66, 0.60);
+@n_300_a: rgba(9, 30, 66, 0.66);
+@n_400_a: rgba(9, 30, 66, 0.71);
+@n_500_a: rgba(9, 30, 66, 0.77);
+@n_600_a: rgba(9, 30, 66, 0.82);
+@n_700_a: rgba(9, 30, 66, 0.89);
+@n_800_a: rgba(9, 30, 66, 0.95);
+@dn_900: #E6EDFA;
+@dn_800: #DCE5F5;
+@dn_700: #CED9EB;
+@dn_600: #B8C7E0;
+@dn_500: #ABBBD6;
+@dn_400: #9FB0CC;
+@dn_300: #8C9CB8;
+@dn_200: #7988A3;
+@dn_100: #67758F;
+@dn_90: #56637A;
+@dn_80: #455166;
+@dn_70: #3B475C;
+@dn_60: #313D52;
+@dn_50: #283447;
+@dn_40: #202B3D;
+@dn_30: #1B2638;
+@dn_20: #121A29;
+@dn_10: #0E1624;
+@dn_0: #0D1424;
+@dn_800_a: rgba(13, 20, 36, 0.06);
+@dn_700_a: rgba(13, 20, 36, 0.14);
+@dn_600_a: rgba(13, 20, 36, 0.18);
+@dn_500_a: rgba(13, 20, 36, 0.29);
+@dn_400_a: rgba(13, 20, 36, 0.36);
+@dn_300_a: rgba(13, 20, 36, 0.40);
+@dn_200_a: rgba(13, 20, 36, 0.47);
+@dn_100_a: rgba(13, 20, 36, 0.53);
+@dn_90_a: rgba(13, 20, 36, 0.63);
+@dn_80_a: rgba(13, 20, 36, 0.73);
+@dn_70_a: rgba(13, 20, 36, 0.78);
+@dn_60_a: rgba(13, 20, 36, 0.81);
+@dn_50_a: rgba(13, 20, 36, 0.85);
+@dn_40_a: rgba(13, 20, 36, 0.89);
+@dn_30_a: rgba(13, 20, 36, 0.92);
+@dn_20_a: rgba(13, 20, 36, 0.95);
+@dn_10_a: rgba(13, 20, 36, 0.97);"
+`;
+
+exports[`on yarn build output files should match snapshots less 2`] = `
+"
+
+@r_50: #FFEBE6;
+@r_75: #FFBDAD;
+@r_100: #FF8F73;
+@r_200: #FF7452;
+@r_300: #FF5630;
+@r_400: #DE350B;
+@r_500: #BF2600;
+@y_50: #FFFAE6;
+@y_75: #FFF0B3;
+@y_100: #FFE380;
+@y_200: #FFC400;
+@y_300: #FFAB00;
+@y_400: #FF991F;
+@y_500: #FF8B00;
+@g_50: #E3FCEF;
+@g_75: #ABF5D1;
+@g_100: #79F2C0;
+@g_200: #57D9A3;
+@g_300: #36B37E;
+@g_400: #00875A;
+@g_500: #006644;
+@b_50: #DEEBFF;
+@b_75: #B3D4FF;
+@b_100: #4C9AFF;
+@b_200: #2684FF;
+@b_300: #0065FF;
+@b_400: #0052CC;
+@b_500: #0747A6;
+@p_50: #EAE6FF;
+@p_75: #C0B6F2;
+@p_100: #998DD9;
+@p_200: #8777D9;
+@p_300: #6554C0;
+@p_400: #5243AA;
+@p_500: #403294;
+@t_50: #E6FCFF;
+@t_75: #B3F5FF;
+@t_100: #79E2F2;
+@t_200: #00C7E6;
+@t_300: #00B8D9;
+@t_400: #00A3BF;
+@t_500: #008DA6;
+@n_0: #FFFFFF;
+@n_10: #FAFBFC;
+@n_20: #F4F5F7;
+@n_30: #EBECF0;
+@n_40: #DFE1E6;
+@n_50: #C1C7D0;
+@n_60: #B3BAC5;
+@n_70: #A5ADBA;
+@n_80: #97A0AF;
+@n_90: #8993A4;
+@n_100: #7A869A;
+@n_200: #6B778C;
+@n_300: #5E6C84;
+@n_400: #505F79;
+@n_500: #42526E;
+@n_600: #344563;
+@n_700: #253858;
+@n_800: #172B4D;
+@n_900: #091E42;
+@n_10_a: rgba(9, 30, 66, 0.02);
+@n_20_a: rgba(9, 30, 66, 0.04);
+@n_30_a: rgba(9, 30, 66, 0.08);
+@n_40_a: rgba(9, 30, 66, 0.13);
+@n_50_a: rgba(9, 30, 66, 0.25);
+@n_60_a: rgba(9, 30, 66, 0.31);
+@n_70_a: rgba(9, 30, 66, 0.36);
+@n_80_a: rgba(9, 30, 66, 0.42);
+@n_90_a: rgba(9, 30, 66, 0.48);
+@n_100_a: rgba(9, 30, 66, 0.54);
+@n_200_a: rgba(9, 30, 66, 0.60);
+@n_300_a: rgba(9, 30, 66, 0.66);
+@n_400_a: rgba(9, 30, 66, 0.71);
+@n_500_a: rgba(9, 30, 66, 0.77);
+@n_600_a: rgba(9, 30, 66, 0.82);
+@n_700_a: rgba(9, 30, 66, 0.89);
+@n_800_a: rgba(9, 30, 66, 0.95);
+@dn_900: #E6EDFA;
+@dn_800: #DCE5F5;
+@dn_700: #CED9EB;
+@dn_600: #B8C7E0;
+@dn_500: #ABBBD6;
+@dn_400: #9FB0CC;
+@dn_300: #8C9CB8;
+@dn_200: #7988A3;
+@dn_100: #67758F;
+@dn_90: #56637A;
+@dn_80: #455166;
+@dn_70: #3B475C;
+@dn_60: #313D52;
+@dn_50: #283447;
+@dn_40: #202B3D;
+@dn_30: #1B2638;
+@dn_20: #121A29;
+@dn_10: #0E1624;
+@dn_0: #0D1424;
+@dn_800_a: rgba(13, 20, 36, 0.06);
+@dn_700_a: rgba(13, 20, 36, 0.14);
+@dn_600_a: rgba(13, 20, 36, 0.18);
+@dn_500_a: rgba(13, 20, 36, 0.29);
+@dn_400_a: rgba(13, 20, 36, 0.36);
+@dn_300_a: rgba(13, 20, 36, 0.40);
+@dn_200_a: rgba(13, 20, 36, 0.47);
+@dn_100_a: rgba(13, 20, 36, 0.53);
+@dn_90_a: rgba(13, 20, 36, 0.63);
+@dn_80_a: rgba(13, 20, 36, 0.73);
+@dn_70_a: rgba(13, 20, 36, 0.78);
+@dn_60_a: rgba(13, 20, 36, 0.81);
+@dn_50_a: rgba(13, 20, 36, 0.85);
+@dn_40_a: rgba(13, 20, 36, 0.89);
+@dn_30_a: rgba(13, 20, 36, 0.92);
+@dn_20_a: rgba(13, 20, 36, 0.95);
+@dn_10_a: rgba(13, 20, 36, 0.97);
+@layer_100: 100;
+@layer_300: 300;
+@layer_200: 200;
+@layer_400: 400;
+@layer_500: 500;
+@layer_510: 510;
+@layer_600: 600;
+@layer_700: 700;
+@layer_800: 800;
+@grid_0_25_x: 2;
+@grid_0_5_x: 4;
+@grid_1_x: 8;
+@messaging_colors_text_normal_resting: #42526E;
+@messaging_colors_text_normal_highlight: #344563;
+@messaging_colors_text_bold_resting: #FFFFFF;"
+`;
+
+exports[`on yarn build output files should match snapshots less 3`] = `
+"
+
+@layer_100: 100;
+@layer_300: 300;
+@layer_200: 200;
+@layer_400: 400;
+@layer_500: 500;
+@layer_510: 510;
+@layer_600: 600;
+@layer_700: 700;
+@layer_800: 800;"
+`;
+
+exports[`on yarn build output files should match snapshots less 4`] = `
+"
+
+@messaging_colors_text_normal_resting: #42526E;
+@messaging_colors_text_normal_highlight: #344563;
+@messaging_colors_text_bold_resting: #FFFFFF;"
+`;
+
+exports[`on yarn build output files should match snapshots less 5`] = `
+"
+
+@grid_0_25_x: 2;
+@grid_0_5_x: 4;
+@grid_1_x: 8;"
+`;
+
+exports[`on yarn build output files should match snapshots scss 1`] = `
+"
+
+$r_50: #FFEBE6;
+$r_75: #FFBDAD;
+$r_100: #FF8F73;
+$r_200: #FF7452;
+$r_300: #FF5630;
+$r_400: #DE350B;
+$r_500: #BF2600;
+$y_50: #FFFAE6;
+$y_75: #FFF0B3;
+$y_100: #FFE380;
+$y_200: #FFC400;
+$y_300: #FFAB00;
+$y_400: #FF991F;
+$y_500: #FF8B00;
+$g_50: #E3FCEF;
+$g_75: #ABF5D1;
+$g_100: #79F2C0;
+$g_200: #57D9A3;
+$g_300: #36B37E;
+$g_400: #00875A;
+$g_500: #006644;
+$b_50: #DEEBFF;
+$b_75: #B3D4FF;
+$b_100: #4C9AFF;
+$b_200: #2684FF;
+$b_300: #0065FF;
+$b_400: #0052CC;
+$b_500: #0747A6;
+$p_50: #EAE6FF;
+$p_75: #C0B6F2;
+$p_100: #998DD9;
+$p_200: #8777D9;
+$p_300: #6554C0;
+$p_400: #5243AA;
+$p_500: #403294;
+$t_50: #E6FCFF;
+$t_75: #B3F5FF;
+$t_100: #79E2F2;
+$t_200: #00C7E6;
+$t_300: #00B8D9;
+$t_400: #00A3BF;
+$t_500: #008DA6;
+$n_0: #FFFFFF;
+$n_10: #FAFBFC;
+$n_20: #F4F5F7;
+$n_30: #EBECF0;
+$n_40: #DFE1E6;
+$n_50: #C1C7D0;
+$n_60: #B3BAC5;
+$n_70: #A5ADBA;
+$n_80: #97A0AF;
+$n_90: #8993A4;
+$n_100: #7A869A;
+$n_200: #6B778C;
+$n_300: #5E6C84;
+$n_400: #505F79;
+$n_500: #42526E;
+$n_600: #344563;
+$n_700: #253858;
+$n_800: #172B4D;
+$n_900: #091E42;
+$n_10_a: rgba(9, 30, 66, 0.02);
+$n_20_a: rgba(9, 30, 66, 0.04);
+$n_30_a: rgba(9, 30, 66, 0.08);
+$n_40_a: rgba(9, 30, 66, 0.13);
+$n_50_a: rgba(9, 30, 66, 0.25);
+$n_60_a: rgba(9, 30, 66, 0.31);
+$n_70_a: rgba(9, 30, 66, 0.36);
+$n_80_a: rgba(9, 30, 66, 0.42);
+$n_90_a: rgba(9, 30, 66, 0.48);
+$n_100_a: rgba(9, 30, 66, 0.54);
+$n_200_a: rgba(9, 30, 66, 0.60);
+$n_300_a: rgba(9, 30, 66, 0.66);
+$n_400_a: rgba(9, 30, 66, 0.71);
+$n_500_a: rgba(9, 30, 66, 0.77);
+$n_600_a: rgba(9, 30, 66, 0.82);
+$n_700_a: rgba(9, 30, 66, 0.89);
+$n_800_a: rgba(9, 30, 66, 0.95);
+$dn_900: #E6EDFA;
+$dn_800: #DCE5F5;
+$dn_700: #CED9EB;
+$dn_600: #B8C7E0;
+$dn_500: #ABBBD6;
+$dn_400: #9FB0CC;
+$dn_300: #8C9CB8;
+$dn_200: #7988A3;
+$dn_100: #67758F;
+$dn_90: #56637A;
+$dn_80: #455166;
+$dn_70: #3B475C;
+$dn_60: #313D52;
+$dn_50: #283447;
+$dn_40: #202B3D;
+$dn_30: #1B2638;
+$dn_20: #121A29;
+$dn_10: #0E1624;
+$dn_0: #0D1424;
+$dn_800_a: rgba(13, 20, 36, 0.06);
+$dn_700_a: rgba(13, 20, 36, 0.14);
+$dn_600_a: rgba(13, 20, 36, 0.18);
+$dn_500_a: rgba(13, 20, 36, 0.29);
+$dn_400_a: rgba(13, 20, 36, 0.36);
+$dn_300_a: rgba(13, 20, 36, 0.40);
+$dn_200_a: rgba(13, 20, 36, 0.47);
+$dn_100_a: rgba(13, 20, 36, 0.53);
+$dn_90_a: rgba(13, 20, 36, 0.63);
+$dn_80_a: rgba(13, 20, 36, 0.73);
+$dn_70_a: rgba(13, 20, 36, 0.78);
+$dn_60_a: rgba(13, 20, 36, 0.81);
+$dn_50_a: rgba(13, 20, 36, 0.85);
+$dn_40_a: rgba(13, 20, 36, 0.89);
+$dn_30_a: rgba(13, 20, 36, 0.92);
+$dn_20_a: rgba(13, 20, 36, 0.95);
+$dn_10_a: rgba(13, 20, 36, 0.97);"
+`;
+
+exports[`on yarn build output files should match snapshots scss 2`] = `
+"
+
+$r_50: #FFEBE6;
+$r_75: #FFBDAD;
+$r_100: #FF8F73;
+$r_200: #FF7452;
+$r_300: #FF5630;
+$r_400: #DE350B;
+$r_500: #BF2600;
+$y_50: #FFFAE6;
+$y_75: #FFF0B3;
+$y_100: #FFE380;
+$y_200: #FFC400;
+$y_300: #FFAB00;
+$y_400: #FF991F;
+$y_500: #FF8B00;
+$g_50: #E3FCEF;
+$g_75: #ABF5D1;
+$g_100: #79F2C0;
+$g_200: #57D9A3;
+$g_300: #36B37E;
+$g_400: #00875A;
+$g_500: #006644;
+$b_50: #DEEBFF;
+$b_75: #B3D4FF;
+$b_100: #4C9AFF;
+$b_200: #2684FF;
+$b_300: #0065FF;
+$b_400: #0052CC;
+$b_500: #0747A6;
+$p_50: #EAE6FF;
+$p_75: #C0B6F2;
+$p_100: #998DD9;
+$p_200: #8777D9;
+$p_300: #6554C0;
+$p_400: #5243AA;
+$p_500: #403294;
+$t_50: #E6FCFF;
+$t_75: #B3F5FF;
+$t_100: #79E2F2;
+$t_200: #00C7E6;
+$t_300: #00B8D9;
+$t_400: #00A3BF;
+$t_500: #008DA6;
+$n_0: #FFFFFF;
+$n_10: #FAFBFC;
+$n_20: #F4F5F7;
+$n_30: #EBECF0;
+$n_40: #DFE1E6;
+$n_50: #C1C7D0;
+$n_60: #B3BAC5;
+$n_70: #A5ADBA;
+$n_80: #97A0AF;
+$n_90: #8993A4;
+$n_100: #7A869A;
+$n_200: #6B778C;
+$n_300: #5E6C84;
+$n_400: #505F79;
+$n_500: #42526E;
+$n_600: #344563;
+$n_700: #253858;
+$n_800: #172B4D;
+$n_900: #091E42;
+$n_10_a: rgba(9, 30, 66, 0.02);
+$n_20_a: rgba(9, 30, 66, 0.04);
+$n_30_a: rgba(9, 30, 66, 0.08);
+$n_40_a: rgba(9, 30, 66, 0.13);
+$n_50_a: rgba(9, 30, 66, 0.25);
+$n_60_a: rgba(9, 30, 66, 0.31);
+$n_70_a: rgba(9, 30, 66, 0.36);
+$n_80_a: rgba(9, 30, 66, 0.42);
+$n_90_a: rgba(9, 30, 66, 0.48);
+$n_100_a: rgba(9, 30, 66, 0.54);
+$n_200_a: rgba(9, 30, 66, 0.60);
+$n_300_a: rgba(9, 30, 66, 0.66);
+$n_400_a: rgba(9, 30, 66, 0.71);
+$n_500_a: rgba(9, 30, 66, 0.77);
+$n_600_a: rgba(9, 30, 66, 0.82);
+$n_700_a: rgba(9, 30, 66, 0.89);
+$n_800_a: rgba(9, 30, 66, 0.95);
+$dn_900: #E6EDFA;
+$dn_800: #DCE5F5;
+$dn_700: #CED9EB;
+$dn_600: #B8C7E0;
+$dn_500: #ABBBD6;
+$dn_400: #9FB0CC;
+$dn_300: #8C9CB8;
+$dn_200: #7988A3;
+$dn_100: #67758F;
+$dn_90: #56637A;
+$dn_80: #455166;
+$dn_70: #3B475C;
+$dn_60: #313D52;
+$dn_50: #283447;
+$dn_40: #202B3D;
+$dn_30: #1B2638;
+$dn_20: #121A29;
+$dn_10: #0E1624;
+$dn_0: #0D1424;
+$dn_800_a: rgba(13, 20, 36, 0.06);
+$dn_700_a: rgba(13, 20, 36, 0.14);
+$dn_600_a: rgba(13, 20, 36, 0.18);
+$dn_500_a: rgba(13, 20, 36, 0.29);
+$dn_400_a: rgba(13, 20, 36, 0.36);
+$dn_300_a: rgba(13, 20, 36, 0.40);
+$dn_200_a: rgba(13, 20, 36, 0.47);
+$dn_100_a: rgba(13, 20, 36, 0.53);
+$dn_90_a: rgba(13, 20, 36, 0.63);
+$dn_80_a: rgba(13, 20, 36, 0.73);
+$dn_70_a: rgba(13, 20, 36, 0.78);
+$dn_60_a: rgba(13, 20, 36, 0.81);
+$dn_50_a: rgba(13, 20, 36, 0.85);
+$dn_40_a: rgba(13, 20, 36, 0.89);
+$dn_30_a: rgba(13, 20, 36, 0.92);
+$dn_20_a: rgba(13, 20, 36, 0.95);
+$dn_10_a: rgba(13, 20, 36, 0.97);
+$layer_100: 100;
+$layer_300: 300;
+$layer_200: 200;
+$layer_400: 400;
+$layer_500: 500;
+$layer_510: 510;
+$layer_600: 600;
+$layer_700: 700;
+$layer_800: 800;
+$grid_0_25_x: 2;
+$grid_0_5_x: 4;
+$grid_1_x: 8;
+$messaging_colors_text_normal_resting: #42526E;
+$messaging_colors_text_normal_highlight: #344563;
+$messaging_colors_text_bold_resting: #FFFFFF;"
+`;
+
+exports[`on yarn build output files should match snapshots scss 3`] = `
+"
+
+$layer_100: 100;
+$layer_300: 300;
+$layer_200: 200;
+$layer_400: 400;
+$layer_500: 500;
+$layer_510: 510;
+$layer_600: 600;
+$layer_700: 700;
+$layer_800: 800;"
+`;
+
+exports[`on yarn build output files should match snapshots scss 4`] = `
+"
+
+$messaging_colors_text_normal_resting: #42526E;
+$messaging_colors_text_normal_highlight: #344563;
+$messaging_colors_text_bold_resting: #FFFFFF;"
+`;
+
+exports[`on yarn build output files should match snapshots scss 5`] = `
+"
+
+$grid_0_25_x: 2;
+$grid_0_5_x: 4;
+$grid_1_x: 8;"
+`;

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -554,14 +554,6 @@ export const messagingColorsTextBoldResting = \\"#FFFFFF\\";"
 exports[`on yarn build output files should match snapshots js 3`] = `
 "
 
-export const messagingColorsTextNormalResting = \\"#42526E\\";
-export const messagingColorsTextNormalHighlight = \\"#344563\\";
-export const messagingColorsTextBoldResting = \\"#FFFFFF\\";"
-`;
-
-exports[`on yarn build output files should match snapshots js 4`] = `
-"
-
 export const layer100 = 100;
 export const layer300 = 300;
 export const layer200 = 200;
@@ -571,6 +563,14 @@ export const layer510 = 510;
 export const layer600 = 600;
 export const layer700 = 700;
 export const layer800 = 800;"
+`;
+
+exports[`on yarn build output files should match snapshots js 4`] = `
+"
+
+export const messagingColorsTextNormalResting = \\"#42526E\\";
+export const messagingColorsTextNormalHighlight = \\"#344563\\";
+export const messagingColorsTextBoldResting = \\"#FFFFFF\\";"
 `;
 
 exports[`on yarn build output files should match snapshots js 5`] = `

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,10 +1,13 @@
 /// SNAPSHOT TESTS
 const fs = require('fs');
 const util = require('util');
+const path = require('path');
 const globby = require('globby');
 const { execSync } = require('child_process');
 const cases = require('jest-in-case');
 const readFile = util.promisify(fs.readFile);
+// const { toMatchFile } = require('jest-file-snapshot');
+// expect.extend({ toMatchFile });
 
 const stripComments = (file) => {
   return file.replace(/\/\*([^*]|[\r\n]|(\*+([^*\/]|[\r\n])))*\*\/+/gi, '')
@@ -20,15 +23,11 @@ describe('on yarn build', () => {
     console.timeEnd('CLEAN');
   });
 
-  cases('output files should match snapshots', async opts => {
-    const filePaths = await globby(opts.pattern, { ignore: ['CHANGELOG.md', 'package.json']});
-    await Promise.all(filePaths.map(async filePath => {
-      const file = await readFile(filePath, 'utf-8');
-      return file;
-    })).then(files => {
-      files.forEach(file => {
-        expect(stripComments(file)).toMatchSnapshot();
-      })
+  cases('output files should match snapshots', opts => {
+    const filePaths = globby.sync(opts.pattern, { ignore: ['CHANGELOG.md', 'package.json']});
+    filePaths.sort().forEach(filePath => {
+      const file = fs.readFileSync(filePath, 'utf-8').toString();
+      expect(stripComments(file)).toMatchSnapshot();
     });
   }, [
     { pattern: './packages/design-tokens-css/*.css', name: 'css' },

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,7 +1,41 @@
-var fs = require('fs');
+/// SNAPSHOT TESTS
+const fs = require('fs');
+const util = require('util');
+const globby = require('globby');
+const { execSync } = require('child_process');
+const cases = require('jest-in-case');
+const readFile = util.promisify(fs.readFile);
 
-describe('test test', () => {
-  it('should pass',() => {
-    expect(true);
-  })
+const stripComments = (file) => {
+  return file.replace(/\/\*([^*]|[\r\n]|(\*+([^*\/]|[\r\n])))*\*\/+/gi, '')
+}
+
+describe('on yarn build', () => {
+  beforeAll(() => {
+    execSync('yarn build');
+  });
+  afterAll(() => {
+    console.time('CLEAN');
+    rimraf.sync('packages/*/!(package.json)*/!(package.json)*');
+    console.timeEnd('CLEAN');
+  });
+
+  cases('output files should match snapshots', async opts => {
+    const filePaths = await globby(opts.pattern, { ignore: ['CHANGELOG.md', 'package.json']});
+    await Promise.all(filePaths.map(async filePath => {
+      const file = await readFile(filePath, 'utf-8');
+      return file;
+    })).then(files => {
+      files.forEach(file => {
+        expect(stripComments(file)).toMatchSnapshot();
+      })
+    });
+  }, [
+    { pattern: './packages/design-tokens-css/*.css', name: 'css' },
+    { pattern: './packages/design-tokens-scss/*.scss', name: 'scss' },
+    { pattern: './packages/design-tokens-less/*.less', name: 'less' },
+    { pattern: './packages/design-tokens-js/src/*.js', name: 'js' },
+    { pattern: './packages/design-tokens-json/*/*', name: 'json' },
+  ]);
+
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,13 +1,8 @@
 /// SNAPSHOT TESTS
 const fs = require('fs');
-const util = require('util');
-const path = require('path');
 const globby = require('globby');
 const { execSync } = require('child_process');
 const cases = require('jest-in-case');
-const readFile = util.promisify(fs.readFile);
-// const { toMatchFile } = require('jest-file-snapshot');
-// expect.extend({ toMatchFile });
 
 const stripComments = (file) => {
   return file.replace(/\/\*([^*]|[\r\n]|(\*+([^*\/]|[\r\n])))*\*\/+/gi, '')
@@ -18,9 +13,7 @@ describe('on yarn build', () => {
     execSync('yarn build');
   });
   afterAll(() => {
-    console.time('CLEAN');
     rimraf.sync('packages/*/!(package.json)*/!(package.json)*');
-    console.timeEnd('CLEAN');
   });
 
   cases('output files should match snapshots', opts => {

--- a/build.js
+++ b/build.js
@@ -1,6 +1,5 @@
 const rimraf = require('rimraf');
 const StyleDictionaryPackage = require('style-dictionary');
-
 const actions = require('./config/actions');
 const formats = require('./config/formats');
 const transforms = require('./config/transforms').transforms;
@@ -10,6 +9,7 @@ const customFormats = require('./config/customFormats');
 // bypass style-dictionary's deep merge and let node do it
 // other example here: https://github.com/amzn/style-dictionary/tree/master/examples/advanced/node-modules-as-config-and-properties
 const properties = require('./properties');
+
 
 // outputs a file configuration object
 function createFile(format, name, filter) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "inquirer": "^6.3.1",
+    "jest-in-case": "^1.0.2",
     "lodash": "^4.17.11",
     "style-dictionary": "^2.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "inquirer": "^6.3.1",
+    "jest-file-snapshot": "^0.3.6",
     "jest-in-case": "^1.0.2",
     "lodash": "^4.17.11",
     "style-dictionary": "^2.7.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "inquirer": "^6.3.1",
-    "jest-file-snapshot": "^0.3.6",
     "jest-in-case": "^1.0.2",
     "lodash": "^4.17.11",
     "style-dictionary": "^2.7.0"

--- a/packages/design-tokens-typescript/package.json
+++ b/packages/design-tokens-typescript/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "@gwyneplaine/design-tokens-typescript",
-  "version": "0.0.1",
-  "main": "index.ts",
-  "license": "ISC",
-  "author": "Atlassian"
-}

--- a/yarn-error.log
+++ b/yarn-error.log
@@ -1,11 +1,11 @@
 Arguments: 
-  /Users/clee/.nvm/versions/node/v8.15.0/bin/node /usr/local/Cellar/yarn/1.13.0/libexec/bin/yarn.js version
+  /Users/clee/.nvm/versions/node/v8.15.0/bin/node /Users/clee/Thinkmill/projects/tokens-distribution-spike/node_modules/.bin/yarn add jest-match-file
 
 PATH: 
   /Users/clee/.nvm/versions/node/v8.15.0/bin:./node_modules/.bin:/usr/local/git/bin:/sw/bin/:/usr/local/bin:/usr/local/:/usr/local/sbin:/usr/local/mysql/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/
 
 Yarn version: 
-  1.13.0
+  1.15.2
 
 Node version: 
   8.15.0
@@ -14,17 +14,17 @@ Platform:
   darwin x64
 
 Trace: 
-  Error: canceled
-      at Interface.<anonymous> (/usr/local/Cellar/yarn/1.13.0/libexec/lib/cli.js:125657:13)
-      at emitNone (events.js:106:13)
-      at Interface.emit (events.js:208:7)
-      at Interface._ttyWrite (readline.js:774:16)
-      at ReadStream.onkeypress (readline.js:158:10)
+  Error: https://registry.yarnpkg.com/jest-match-file: Not found
+      at Request.params.callback [as _callback] (/Users/clee/Thinkmill/projects/tokens-distribution-spike/node_modules/yarn/lib/cli.js:66058:18)
+      at Request.self.callback (/Users/clee/Thinkmill/projects/tokens-distribution-spike/node_modules/yarn/lib/cli.js:129541:22)
       at emitTwo (events.js:126:13)
-      at ReadStream.emit (events.js:214:7)
-      at emitKeys (internal/readline.js:420:14)
-      at emitKeys.next (<anonymous>)
-      at ReadStream.onData (readline.js:1010:36)
+      at Request.emit (events.js:214:7)
+      at Request.<anonymous> (/Users/clee/Thinkmill/projects/tokens-distribution-spike/node_modules/yarn/lib/cli.js:130513:10)
+      at emitOne (events.js:116:13)
+      at Request.emit (events.js:211:7)
+      at IncomingMessage.<anonymous> (/Users/clee/Thinkmill/projects/tokens-distribution-spike/node_modules/yarn/lib/cli.js:130435:12)
+      at Object.onceWrapper (events.js:313:30)
+      at emitNone (events.js:111:20)
 
 npm manifest: 
   {
@@ -33,12 +33,17 @@ npm manifest:
     "main": "index.js",
     "license": "MIT",
     "scripts": {
-      "build": "node ./build.js",
+      "build": "node ./build.js && preconstruct build",
       "changeset": "build-releases changeset",
-      "version": "build-releases version",
-      "publish": "build-releases publish"
+      "release:version": "build-releases version",
+      "release:publish": "build-releases publish --public",
+      "test": "jest",
+      "add:package": "node ./add-pkg.js"
     },
     "dependencies": {
+      "chalk": "^2.4.2",
+      "inquirer": "^6.3.1",
+      "jest-in-case": "^1.0.2",
       "lodash": "^4.17.11",
       "style-dictionary": "^2.7.0"
     },
@@ -51,7 +56,14 @@ npm manifest:
     "devDependencies": {
       "@atlaskit/build-releases": "^3.0.3",
       "globby": "^9.2.0",
+      "jest": "^24.7.1",
+      "preconstruct": "^0.0.54",
       "rimraf": "^2.6.3"
+    },
+    "preconstruct": {
+      "packages": [
+        "packages/design-tokens-js"
+      ]
     }
   }
 
@@ -95,6 +107,363 @@ Lockfile:
       projector-spawn "^1.0.1"
       uuid "^3.1.0"
   
+  "@babel/code-frame@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+    integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+    dependencies:
+      "@babel/highlight" "^7.0.0"
+  
+  "@babel/core@^7.1.0", "@babel/core@^7.1.2":
+    version "7.4.3"
+    resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.3.tgz#198d6d3af4567be3989550d97e068de94503074f"
+    integrity sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==
+    dependencies:
+      "@babel/code-frame" "^7.0.0"
+      "@babel/generator" "^7.4.0"
+      "@babel/helpers" "^7.4.3"
+      "@babel/parser" "^7.4.3"
+      "@babel/template" "^7.4.0"
+      "@babel/traverse" "^7.4.3"
+      "@babel/types" "^7.4.0"
+      convert-source-map "^1.1.0"
+      debug "^4.1.0"
+      json5 "^2.1.0"
+      lodash "^4.17.11"
+      resolve "^1.3.2"
+      semver "^5.4.1"
+      source-map "^0.5.0"
+  
+  "@babel/generator@^7.0.0", "@babel/generator@^7.4.0":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.0.tgz#c230e79589ae7a729fd4631b9ded4dc220418196"
+    integrity sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==
+    dependencies:
+      "@babel/types" "^7.4.0"
+      jsesc "^2.5.1"
+      lodash "^4.17.11"
+      source-map "^0.5.0"
+      trim-right "^1.0.1"
+  
+  "@babel/helper-create-class-features-plugin@^7.4.0":
+    version "7.4.3"
+    resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz#5bbd279c6c3ac6a60266b89bbfe7f8021080a1ef"
+    integrity sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==
+    dependencies:
+      "@babel/helper-function-name" "^7.1.0"
+      "@babel/helper-member-expression-to-functions" "^7.0.0"
+      "@babel/helper-optimise-call-expression" "^7.0.0"
+      "@babel/helper-plugin-utils" "^7.0.0"
+      "@babel/helper-replace-supers" "^7.4.0"
+      "@babel/helper-split-export-declaration" "^7.4.0"
+  
+  "@babel/helper-function-name@^7.1.0":
+    version "7.1.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+    integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+    dependencies:
+      "@babel/helper-get-function-arity" "^7.0.0"
+      "@babel/template" "^7.1.0"
+      "@babel/types" "^7.0.0"
+  
+  "@babel/helper-get-function-arity@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+    integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+    dependencies:
+      "@babel/types" "^7.0.0"
+  
+  "@babel/helper-member-expression-to-functions@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
+    integrity sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==
+    dependencies:
+      "@babel/types" "^7.0.0"
+  
+  "@babel/helper-module-imports@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+    integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
+    dependencies:
+      "@babel/types" "^7.0.0"
+  
+  "@babel/helper-optimise-call-expression@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
+    integrity sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==
+    dependencies:
+      "@babel/types" "^7.0.0"
+  
+  "@babel/helper-plugin-utils@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+    integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
+  
+  "@babel/helper-replace-supers@^7.4.0":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz#4f56adb6aedcd449d2da9399c2dcf0545463b64c"
+    integrity sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==
+    dependencies:
+      "@babel/helper-member-expression-to-functions" "^7.0.0"
+      "@babel/helper-optimise-call-expression" "^7.0.0"
+      "@babel/traverse" "^7.4.0"
+      "@babel/types" "^7.4.0"
+  
+  "@babel/helper-split-export-declaration@^7.4.0":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz#571bfd52701f492920d63b7f735030e9a3e10b55"
+    integrity sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==
+    dependencies:
+      "@babel/types" "^7.4.0"
+  
+  "@babel/helpers@^7.4.3":
+    version "7.4.3"
+    resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.3.tgz#7b1d354363494b31cb9a2417ae86af32b7853a3b"
+    integrity sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==
+    dependencies:
+      "@babel/template" "^7.4.0"
+      "@babel/traverse" "^7.4.3"
+      "@babel/types" "^7.4.0"
+  
+  "@babel/highlight@^7.0.0":
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+    integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+    dependencies:
+      chalk "^2.0.0"
+      esutils "^2.0.2"
+      js-tokens "^4.0.0"
+  
+  "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.0", "@babel/parser@^7.4.3":
+    version "7.4.3"
+    resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
+    integrity sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==
+  
+  "@babel/plugin-proposal-class-properties@^7.3.4":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz#d70db61a2f1fd79de927eea91f6411c964e084b8"
+    integrity sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==
+    dependencies:
+      "@babel/helper-create-class-features-plugin" "^7.4.0"
+      "@babel/helper-plugin-utils" "^7.0.0"
+  
+  "@babel/plugin-syntax-flow@^7.2.0":
+    version "7.2.0"
+    resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz#a765f061f803bc48f240c26f8747faf97c26bf7c"
+    integrity sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==
+    dependencies:
+      "@babel/helper-plugin-utils" "^7.0.0"
+  
+  "@babel/plugin-syntax-object-rest-spread@^7.0.0":
+    version "7.2.0"
+    resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
+    integrity sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
+    dependencies:
+      "@babel/helper-plugin-utils" "^7.0.0"
+  
+  "@babel/plugin-transform-flow-strip-types@^7.4.0":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.0.tgz#f3c59eecff68c99b9c96eaafe4fe9d1fa8947138"
+    integrity sha512-C4ZVNejHnfB22vI2TYN4RUp2oCmq6cSEAg4RygSvYZUECRqUu9O4PMEMNJ4wsemaRGg27BbgYctG4BZh+AgIHw==
+    dependencies:
+      "@babel/helper-plugin-utils" "^7.0.0"
+      "@babel/plugin-syntax-flow" "^7.2.0"
+  
+  "@babel/plugin-transform-runtime@^7.2.0":
+    version "7.4.3"
+    resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz#4d6691690ecdc9f5cb8c3ab170a1576c1f556371"
+    integrity sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==
+    dependencies:
+      "@babel/helper-module-imports" "^7.0.0"
+      "@babel/helper-plugin-utils" "^7.0.0"
+      resolve "^1.8.1"
+      semver "^5.5.1"
+  
+  "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.4.0":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
+    integrity sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==
+    dependencies:
+      "@babel/code-frame" "^7.0.0"
+      "@babel/parser" "^7.4.0"
+      "@babel/types" "^7.4.0"
+  
+  "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.0", "@babel/traverse@^7.4.3":
+    version "7.4.3"
+    resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.3.tgz#1a01f078fc575d589ff30c0f71bf3c3d9ccbad84"
+    integrity sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==
+    dependencies:
+      "@babel/code-frame" "^7.0.0"
+      "@babel/generator" "^7.4.0"
+      "@babel/helper-function-name" "^7.1.0"
+      "@babel/helper-split-export-declaration" "^7.4.0"
+      "@babel/parser" "^7.4.3"
+      "@babel/types" "^7.4.0"
+      debug "^4.1.0"
+      globals "^11.1.0"
+      lodash "^4.17.11"
+  
+  "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0":
+    version "7.4.0"
+    resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.0.tgz#670724f77d24cce6cc7d8cf64599d511d164894c"
+    integrity sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==
+    dependencies:
+      esutils "^2.0.2"
+      lodash "^4.17.11"
+      to-fast-properties "^2.0.0"
+  
+  "@cnakazawa/watch@^1.0.3":
+    version "1.0.3"
+    resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
+    integrity sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==
+    dependencies:
+      exec-sh "^0.3.2"
+      minimist "^1.2.0"
+  
+  "@jest/console@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
+    integrity sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==
+    dependencies:
+      "@jest/source-map" "^24.3.0"
+      chalk "^2.0.1"
+      slash "^2.0.0"
+  
+  "@jest/core@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/core/-/core-24.7.1.tgz#6707f50db238d0c5988860680e2e414df0032024"
+    integrity sha512-ivlZ8HX/FOASfHcb5DJpSPFps8ydfUYzLZfgFFqjkLijYysnIEOieg72YRhO4ZUB32xu40hsSMmaw+IGYeKONA==
+    dependencies:
+      "@jest/console" "^24.7.1"
+      "@jest/reporters" "^24.7.1"
+      "@jest/test-result" "^24.7.1"
+      "@jest/transform" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      ansi-escapes "^3.0.0"
+      chalk "^2.0.1"
+      exit "^0.1.2"
+      graceful-fs "^4.1.15"
+      jest-changed-files "^24.7.0"
+      jest-config "^24.7.1"
+      jest-haste-map "^24.7.1"
+      jest-message-util "^24.7.1"
+      jest-regex-util "^24.3.0"
+      jest-resolve-dependencies "^24.7.1"
+      jest-runner "^24.7.1"
+      jest-runtime "^24.7.1"
+      jest-snapshot "^24.7.1"
+      jest-util "^24.7.1"
+      jest-validate "^24.7.0"
+      jest-watcher "^24.7.1"
+      micromatch "^3.1.10"
+      p-each-series "^1.0.0"
+      pirates "^4.0.1"
+      realpath-native "^1.1.0"
+      rimraf "^2.5.4"
+      strip-ansi "^5.0.0"
+  
+  "@jest/environment@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.7.1.tgz#9b9196bc737561f67ac07817d4c5ece772e33135"
+    integrity sha512-wmcTTYc4/KqA+U5h1zQd5FXXynfa7VGP2NfF+c6QeGJ7c+2nStgh65RQWNX62SC716dTtqheTRrZl0j+54oGHw==
+    dependencies:
+      "@jest/fake-timers" "^24.7.1"
+      "@jest/transform" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      jest-mock "^24.7.0"
+  
+  "@jest/fake-timers@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.7.1.tgz#56e5d09bdec09ee81050eaff2794b26c71d19db2"
+    integrity sha512-4vSQJDKfR2jScOe12L9282uiwuwQv9Lk7mgrCSZHA9evB9efB/qx8i0KJxsAKtp8fgJYBJdYY7ZU6u3F4/pyjA==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      jest-message-util "^24.7.1"
+      jest-mock "^24.7.0"
+  
+  "@jest/reporters@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-24.7.1.tgz#38ac0b096cd691bbbe3051ddc25988d42e37773a"
+    integrity sha512-bO+WYNwHLNhrjB9EbPL4kX/mCCG4ZhhfWmO3m4FSpbgr7N83MFejayz30kKjgqr7smLyeaRFCBQMbXpUgnhAJw==
+    dependencies:
+      "@jest/environment" "^24.7.1"
+      "@jest/test-result" "^24.7.1"
+      "@jest/transform" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      chalk "^2.0.1"
+      exit "^0.1.2"
+      glob "^7.1.2"
+      istanbul-api "^2.1.1"
+      istanbul-lib-coverage "^2.0.2"
+      istanbul-lib-instrument "^3.0.1"
+      istanbul-lib-source-maps "^3.0.1"
+      jest-haste-map "^24.7.1"
+      jest-resolve "^24.7.1"
+      jest-runtime "^24.7.1"
+      jest-util "^24.7.1"
+      jest-worker "^24.6.0"
+      node-notifier "^5.2.1"
+      slash "^2.0.0"
+      source-map "^0.6.0"
+      string-length "^2.0.0"
+  
+  "@jest/source-map@^24.3.0":
+    version "24.3.0"
+    resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.3.0.tgz#563be3aa4d224caf65ff77edc95cd1ca4da67f28"
+    integrity sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==
+    dependencies:
+      callsites "^3.0.0"
+      graceful-fs "^4.1.15"
+      source-map "^0.6.0"
+  
+  "@jest/test-result@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.7.1.tgz#19eacdb29a114300aed24db651e5d975f08b6bbe"
+    integrity sha512-3U7wITxstdEc2HMfBX7Yx3JZgiNBubwDqQMh+BXmZXHa3G13YWF3p6cK+5g0hGkN3iufg/vGPl3hLxQXD74Npg==
+    dependencies:
+      "@jest/console" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      "@types/istanbul-lib-coverage" "^2.0.0"
+  
+  "@jest/test-sequencer@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-24.7.1.tgz#9c18e428e1ad945fa74f6233a9d35745ca0e63e0"
+    integrity sha512-84HQkCpVZI/G1zq53gHJvSmhUer4aMYp9tTaffW28Ih5OxfCg8hGr3nTSbL1OhVDRrFZwvF+/R9gY6JRkDUpUA==
+    dependencies:
+      "@jest/test-result" "^24.7.1"
+      jest-haste-map "^24.7.1"
+      jest-runner "^24.7.1"
+      jest-runtime "^24.7.1"
+  
+  "@jest/transform@^24.7.1":
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-24.7.1.tgz#872318f125bcfab2de11f53b465ab1aa780789c2"
+    integrity sha512-EsOUqP9ULuJ66IkZQhI5LufCHlTbi7hrcllRMUEV/tOgqBVQi93+9qEvkX0n8mYpVXQ8VjwmICeRgg58mrtIEw==
+    dependencies:
+      "@babel/core" "^7.1.0"
+      "@jest/types" "^24.7.0"
+      babel-plugin-istanbul "^5.1.0"
+      chalk "^2.0.1"
+      convert-source-map "^1.4.0"
+      fast-json-stable-stringify "^2.0.0"
+      graceful-fs "^4.1.15"
+      jest-haste-map "^24.7.1"
+      jest-regex-util "^24.3.0"
+      jest-util "^24.7.1"
+      micromatch "^3.1.10"
+      realpath-native "^1.1.0"
+      slash "^2.0.0"
+      source-map "^0.6.1"
+      write-file-atomic "2.4.1"
+  
+  "@jest/types@^24.7.0":
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.7.0.tgz#c4ec8d1828cdf23234d9b4ee31f5482a3f04f48b"
+    integrity sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==
+    dependencies:
+      "@types/istanbul-lib-coverage" "^2.0.0"
+      "@types/yargs" "^12.0.9"
+  
   "@mrmlnc/readdir-enhanced@^2.2.1":
     version "2.2.1"
     resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -107,6 +476,44 @@ Lockfile:
     version "1.1.3"
     resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
     integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+  
+  "@types/babel__core@^7.1.0":
+    version "7.1.1"
+    resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.1.tgz#ce9a9e5d92b7031421e1d0d74ae59f572ba48be6"
+    integrity sha512-+hjBtgcFPYyCTo0A15+nxrCVJL7aC6Acg87TXd5OW3QhHswdrOLoles+ldL2Uk8q++7yIfl4tURtztccdeeyOw==
+    dependencies:
+      "@babel/parser" "^7.1.0"
+      "@babel/types" "^7.0.0"
+      "@types/babel__generator" "*"
+      "@types/babel__template" "*"
+      "@types/babel__traverse" "*"
+  
+  "@types/babel__generator@*":
+    version "7.0.2"
+    resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.0.2.tgz#d2112a6b21fad600d7674274293c85dce0cb47fc"
+    integrity sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==
+    dependencies:
+      "@babel/types" "^7.0.0"
+  
+  "@types/babel__template@*":
+    version "7.0.2"
+    resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
+    integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+    dependencies:
+      "@babel/parser" "^7.1.0"
+      "@babel/types" "^7.0.0"
+  
+  "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+    version "7.0.6"
+    resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.6.tgz#328dd1a8fc4cfe3c8458be9477b219ea158fd7b2"
+    integrity sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==
+    dependencies:
+      "@babel/types" "^7.3.0"
+  
+  "@types/estree@0.0.39":
+    version "0.0.39"
+    resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+    integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
   
   "@types/events@*":
     version "3.0.0"
@@ -122,6 +529,11 @@ Lockfile:
       "@types/minimatch" "*"
       "@types/node" "*"
   
+  "@types/istanbul-lib-coverage@^2.0.0":
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
+    integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
+  
   "@types/minimatch@*":
     version "3.0.3"
     resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -132,6 +544,71 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.0.tgz#b0df8d6ef9b5001b2be3a94d909ce3c29a80f9e1"
     integrity sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==
   
+  "@types/node@^11.13.2":
+    version "11.13.4"
+    resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
+    integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
+  
+  "@types/resolve@0.0.8":
+    version "0.0.8"
+    resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+    integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+    dependencies:
+      "@types/node" "*"
+  
+  "@types/stack-utils@^1.0.1":
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+    integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+  
+  "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
+    version "12.0.12"
+    resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
+    integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
+  
+  abab@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+    integrity sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==
+  
+  abbrev@1:
+    version "1.1.1"
+    resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+    integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+  
+  acorn-globals@^4.1.0:
+    version "4.3.2"
+    resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
+    integrity sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==
+    dependencies:
+      acorn "^6.0.1"
+      acorn-walk "^6.0.1"
+  
+  acorn-walk@^6.0.1:
+    version "6.1.1"
+    resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
+    integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
+  
+  acorn@^5.5.3:
+    version "5.7.3"
+    resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+    integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
+  
+  acorn@^6.0.1, acorn@^6.1.1:
+    version "6.1.1"
+    resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+    integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+  
+  ajv@^6.5.5:
+    version "6.10.0"
+    resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+    integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+    dependencies:
+      fast-deep-equal "^2.0.1"
+      fast-json-stable-stringify "^2.0.0"
+      json-schema-traverse "^0.4.1"
+      uri-js "^4.2.2"
+  
   ansi-align@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
@@ -139,17 +616,27 @@ Lockfile:
     dependencies:
       string-width "^2.0.0"
   
-  ansi-escapes@^3.0.0:
+  ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
     version "3.2.0"
     resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
     integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+  
+  ansi-regex@^2.0.0:
+    version "2.1.1"
+    resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+    integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
   
   ansi-regex@^3.0.0:
     version "3.0.0"
     resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
     integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
   
-  ansi-styles@^3.2.1:
+  ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+    version "4.1.0"
+    resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+    integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+  
+  ansi-styles@^3.2.0, ansi-styles@^3.2.1:
     version "3.2.1"
     resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
     integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -160,6 +647,41 @@ Lockfile:
     version "1.3.0"
     resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
     integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
+  
+  anymatch@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
+    integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+    dependencies:
+      micromatch "^3.1.4"
+      normalize-path "^2.1.1"
+  
+  append-transform@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+    integrity sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
+    dependencies:
+      default-require-extensions "^2.0.0"
+  
+  aproba@^1.0.3:
+    version "1.2.0"
+    resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+    integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+  
+  are-we-there-yet@~1.1.2:
+    version "1.1.5"
+    resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
+    integrity sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
+    dependencies:
+      delegates "^1.0.0"
+      readable-stream "^2.0.6"
+  
+  argparse@^1.0.7:
+    version "1.0.10"
+    resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+    integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+    dependencies:
+      sprintf-js "~1.0.2"
   
   arr-diff@^4.0.0:
     version "4.0.0"
@@ -180,6 +702,11 @@ Lockfile:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
     integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
+  
+  array-equal@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+    integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
   
   array-find-index@^1.0.1:
     version "1.0.2"
@@ -216,20 +743,101 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
     integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
   
+  asn1@~0.2.3:
+    version "0.2.4"
+    resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+    integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+    dependencies:
+      safer-buffer "~2.1.0"
+  
+  assert-plus@1.0.0, assert-plus@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+    integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+  
   assign-symbols@^1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
     integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+  
+  astral-regex@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+    integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+  
+  async-limiter@~1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+    integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
   
   async@^1.4.0:
     version "1.5.2"
     resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
     integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
   
+  async@^2.6.1:
+    version "2.6.2"
+    resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+    integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
+    dependencies:
+      lodash "^4.17.11"
+  
+  asynckit@^0.4.0:
+    version "0.4.0"
+    resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+    integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+  
   atob@^2.1.1:
     version "2.1.2"
     resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
     integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+  
+  aws-sign2@~0.7.0:
+    version "0.7.0"
+    resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+    integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+  
+  aws4@^1.8.0:
+    version "1.8.0"
+    resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+    integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+  
+  babel-jest@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.7.1.tgz#73902c9ff15a7dfbdc9994b0b17fcefd96042178"
+    integrity sha512-GPnLqfk8Mtt0i4OemjWkChi73A3ALs4w2/QbG64uAj8b5mmwzxc7jbJVRZt8NJkxi6FopVHog9S3xX6UJKb2qg==
+    dependencies:
+      "@jest/transform" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      "@types/babel__core" "^7.1.0"
+      babel-plugin-istanbul "^5.1.0"
+      babel-preset-jest "^24.6.0"
+      chalk "^2.4.2"
+      slash "^2.0.0"
+  
+  babel-plugin-istanbul@^5.1.0:
+    version "5.1.2"
+    resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.2.tgz#d8c2e2e83f72695d6bfdcd297719c66161d5f0f9"
+    integrity sha512-U3ZVajC+Z69Gim7ZzmD4Wcsq76i/1hqDamBfowc1tWzWjybRy70iWfngP2ME+1CrgcgZ/+muIbPY/Yi0dxdIkQ==
+    dependencies:
+      find-up "^3.0.0"
+      istanbul-lib-instrument "^3.2.0"
+      test-exclude "^5.2.2"
+  
+  babel-plugin-jest-hoist@^24.6.0:
+    version "24.6.0"
+    resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz#f7f7f7ad150ee96d7a5e8e2c5da8319579e78019"
+    integrity sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
+    dependencies:
+      "@types/babel__traverse" "^7.0.6"
+  
+  babel-preset-jest@^24.6.0:
+    version "24.6.0"
+    resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
+    integrity sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==
+    dependencies:
+      "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
+      babel-plugin-jest-hoist "^24.6.0"
   
   babel-runtime@^6.25.0:
     version "6.26.0"
@@ -256,6 +864,18 @@ Lockfile:
       isobject "^3.0.1"
       mixin-deep "^1.2.0"
       pascalcase "^0.1.1"
+  
+  bcrypt-pbkdf@^1.0.0:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+    integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+    dependencies:
+      tweetnacl "^0.14.3"
+  
+  bindings@~1.2.1:
+    version "1.2.1"
+    resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
+    integrity sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=
   
   bitbucket-build-status@^1.0.3:
     version "1.0.3"
@@ -342,6 +962,35 @@ Lockfile:
       split-string "^3.0.2"
       to-regex "^3.0.1"
   
+  browser-process-hrtime@^0.1.2:
+    version "0.1.3"
+    resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
+    integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
+  
+  browser-resolve@^1.11.3:
+    version "1.11.3"
+    resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
+    integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
+    dependencies:
+      resolve "1.1.7"
+  
+  bser@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
+    integrity sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
+    dependencies:
+      node-int64 "^0.4.0"
+  
+  buffer-from@^1.0.0:
+    version "1.1.1"
+    resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+    integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+  
+  builtin-modules@^3.0.0:
+    version "3.1.0"
+    resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+    integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
+  
   bytewise-core@^1.2.2:
     version "1.2.3"
     resolved "https://registry.yarnpkg.com/bytewise-core/-/bytewise-core-1.2.3.tgz#3fb410c7e91558eb1ab22a82834577aa6bd61d42"
@@ -377,6 +1026,11 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
     integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
   
+  callsites@^3.0.0:
+    version "3.1.0"
+    resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+    integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+  
   camelcase-keys@^4.0.0:
     version "4.2.0"
     resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
@@ -391,7 +1045,24 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
     integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
   
-  chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
+  camelcase@^5.0.0:
+    version "5.3.1"
+    resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+    integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+  
+  capture-exit@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
+    integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
+    dependencies:
+      rsvp "^4.8.4"
+  
+  caseless@~0.12.0:
+    version "0.12.0"
+    resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+    integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+  
+  chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
     version "2.4.2"
     resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
     integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -405,10 +1076,25 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
     integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
   
+  chardet@^0.7.0:
+    version "0.7.0"
+    resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+    integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+  
+  chownr@^1.1.1:
+    version "1.1.1"
+    resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+    integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+  
   chunkd@^1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/chunkd/-/chunkd-1.0.0.tgz#4ead4a3704bcce510c4bb4d4a8be30c557836dd1"
     integrity sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==
+  
+  ci-info@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+    integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
   
   ci-parallel-vars@^1.0.0:
     version "1.0.0"
@@ -447,6 +1133,15 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
     integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
   
+  cliui@^4.0.0:
+    version "4.1.0"
+    resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+    integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+    dependencies:
+      string-width "^2.1.1"
+      strip-ansi "^4.0.0"
+      wrap-ansi "^2.0.0"
+  
   cmd-shim@^2.0.2:
     version "2.0.2"
     resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
@@ -454,6 +1149,16 @@ Lockfile:
     dependencies:
       graceful-fs "^4.1.2"
       mkdirp "~0.5.0"
+  
+  co@^4.6.0:
+    version "4.6.0"
+    resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+    integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+  
+  code-point-at@^1.0.0:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+    integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
   
   collection-visit@^1.0.0:
     version "1.0.0"
@@ -475,17 +1180,32 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
     integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
   
-  combined-stream@^1.0.5:
+  combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@~1.0.6:
     version "1.0.7"
     resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
     integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
     dependencies:
       delayed-stream "~1.0.0"
   
+  command-exists@^1.2.6:
+    version "1.2.8"
+    resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
+    integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
+  
+  commander@^2.19.0, commander@~2.20.0:
+    version "2.20.0"
+    resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+    integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+  
   commander@^2.9.0:
     version "2.19.0"
     resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
     integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  
+  compare-versions@^3.2.1:
+    version "3.4.0"
+    resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.4.0.tgz#e0747df5c9cb7f054d6d3dc3e1dbc444f9e92b26"
+    integrity sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==
   
   component-emitter@^1.2.1, component-emitter@~1.2.0:
     version "1.2.1"
@@ -496,6 +1216,18 @@ Lockfile:
     version "0.0.1"
     resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
     integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  
+  console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+    integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+  
+  convert-source-map@^1.1.0, convert-source-map@^1.4.0:
+    version "1.6.0"
+    resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+    integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+    dependencies:
+      safe-buffer "~5.1.1"
   
   cookiejar@2.0.6:
     version "2.0.6"
@@ -512,10 +1244,18 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
     integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
   
-  core-util-is@~1.0.0:
+  core-util-is@1.0.2, core-util-is@~1.0.0:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
     integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+  
+  cross-spawn@^4.0.2:
+    version "4.0.2"
+    resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+    integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+    dependencies:
+      lru-cache "^4.0.1"
+      which "^1.2.9"
   
   cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     version "5.1.0"
@@ -526,6 +1266,29 @@ Lockfile:
       shebang-command "^1.2.0"
       which "^1.2.9"
   
+  cross-spawn@^6.0.0:
+    version "6.0.5"
+    resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+    integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+    dependencies:
+      nice-try "^1.0.4"
+      path-key "^2.0.1"
+      semver "^5.5.0"
+      shebang-command "^1.2.0"
+      which "^1.2.9"
+  
+  cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+    version "0.3.6"
+    resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.6.tgz#f85206cee04efa841f3c5982a74ba96ab20d65ad"
+    integrity sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==
+  
+  cssstyle@^1.0.0:
+    version "1.2.2"
+    resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.2.2.tgz#427ea4d585b18624f6fdbf9de7a2a1a3ba713077"
+    integrity sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==
+    dependencies:
+      cssom "0.3.x"
+  
   currently-unhandled@^0.4.1:
     version "0.4.1"
     resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -533,12 +1296,48 @@ Lockfile:
     dependencies:
       array-find-index "^1.0.1"
   
+  dashdash@^1.12.0:
+    version "1.14.1"
+    resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+    integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+    dependencies:
+      assert-plus "^1.0.0"
+  
+  data-urls@^1.0.0:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+    integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+    dependencies:
+      abab "^2.0.0"
+      whatwg-mimetype "^2.2.0"
+      whatwg-url "^7.0.0"
+  
+  dataloader@^1.4.0:
+    version "1.4.0"
+    resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+    integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+  
+  deasync@^0.1.14:
+    version "0.1.14"
+    resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.14.tgz#232ea2252b443948cad033d792eb3b24b0a3d828"
+    integrity sha512-wN8sIuEqIwyQh72AG7oY6YQODCxIp1eXzEZlZznBuwDF8Q03Tdy9QNp1BNZXeadXoklNrw+Ip1fch+KXo/+ASw==
+    dependencies:
+      bindings "~1.2.1"
+      node-addon-api "^1.6.0"
+  
   debug@2, debug@^2.2.0, debug@^2.3.3:
     version "2.6.9"
     resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
     integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
     dependencies:
       ms "2.0.0"
+  
+  debug@^4.1.0, debug@^4.1.1:
+    version "4.1.1"
+    resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+    integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+    dependencies:
+      ms "^2.1.1"
   
   decamelize-keys@^1.0.0:
     version "1.1.0"
@@ -548,7 +1347,7 @@ Lockfile:
       decamelize "^1.1.0"
       map-obj "^1.0.0"
   
-  decamelize@^1.1.0:
+  decamelize@^1.1.0, decamelize@^1.2.0:
     version "1.2.0"
     resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
     integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -557,6 +1356,23 @@ Lockfile:
     version "0.2.0"
     resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
     integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  
+  deep-extend@^0.6.0:
+    version "0.6.0"
+    resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+    integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+  
+  deep-is@~0.1.3:
+    version "0.1.3"
+    resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+    integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  
+  default-require-extensions@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+    integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
+    dependencies:
+      strip-bom "^3.0.0"
   
   define-properties@^1.1.2:
     version "1.1.3"
@@ -587,15 +1403,60 @@ Lockfile:
       is-descriptor "^1.0.2"
       isobject "^3.0.1"
   
+  del@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+    integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+    dependencies:
+      globby "^6.1.0"
+      is-path-cwd "^1.0.0"
+      is-path-in-cwd "^1.0.0"
+      p-map "^1.1.1"
+      pify "^3.0.0"
+      rimraf "^2.2.8"
+  
   delayed-stream@~1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
     integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
   
+  delegates@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+    integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+  
   detect-indent@^5.0.0:
     version "5.0.0"
     resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
     integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
+  
+  detect-libc@^1.0.2:
+    version "1.0.3"
+    resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+    integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+  
+  detect-newline@^2.1.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+    integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+  
+  diff-sequences@^24.3.0:
+    version "24.3.0"
+    resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
+    integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
+  
+  diff@^4.0.1:
+    version "4.0.1"
+    resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+    integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+  
+  dir-glob@2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+    integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
+    dependencies:
+      arrify "^1.0.1"
+      path-type "^3.0.0"
   
   dir-glob@^2.2.2:
     version "2.2.2"
@@ -604,10 +1465,32 @@ Lockfile:
     dependencies:
       path-type "^3.0.0"
   
+  domexception@^1.0.1:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+    integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+    dependencies:
+      webidl-conversions "^4.0.2"
+  
+  ecc-jsbn@~0.1.1:
+    version "0.1.2"
+    resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+    integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+    dependencies:
+      jsbn "~0.1.0"
+      safer-buffer "^2.1.0"
+  
   editor@^1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
     integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
+  
+  end-of-stream@^1.1.0:
+    version "1.4.1"
+    resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+    integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+    dependencies:
+      once "^1.4.0"
   
   error-ex@^1.2.0, error-ex@^1.3.1:
     version "1.3.2"
@@ -616,7 +1499,7 @@ Lockfile:
     dependencies:
       is-arrayish "^0.2.1"
   
-  es-abstract@^1.7.0:
+  es-abstract@^1.5.1, es-abstract@^1.7.0:
     version "1.13.0"
     resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
     integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
@@ -642,6 +1525,48 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
     integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
   
+  escodegen@^1.9.1:
+    version "1.11.1"
+    resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
+    integrity sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
+    dependencies:
+      esprima "^3.1.3"
+      estraverse "^4.2.0"
+      esutils "^2.0.2"
+      optionator "^0.8.1"
+    optionalDependencies:
+      source-map "~0.6.1"
+  
+  esprima@^3.1.3:
+    version "3.1.3"
+    resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+    integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
+  
+  esprima@^4.0.0:
+    version "4.0.1"
+    resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+    integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+  
+  estraverse@^4.2.0:
+    version "4.2.0"
+    resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+    integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+  
+  estree-walker@^0.6.0:
+    version "0.6.0"
+    resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
+    integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
+  
+  esutils@^2.0.2:
+    version "2.0.2"
+    resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+    integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+  
+  exec-sh@^0.3.2:
+    version "0.3.2"
+    resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
+    integrity sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==
+  
   execa@^0.7.0:
     version "0.7.0"
     resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -655,6 +1580,24 @@ Lockfile:
       signal-exit "^3.0.0"
       strip-eof "^1.0.0"
   
+  execa@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+    integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+    dependencies:
+      cross-spawn "^6.0.0"
+      get-stream "^4.0.0"
+      is-stream "^1.1.0"
+      npm-run-path "^2.0.0"
+      p-finally "^1.0.0"
+      signal-exit "^3.0.0"
+      strip-eof "^1.0.0"
+  
+  exit@^0.1.2:
+    version "0.1.2"
+    resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+    integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
+  
   expand-brackets@^2.1.4:
     version "2.1.4"
     resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -667,6 +1610,18 @@ Lockfile:
       regex-not "^1.0.0"
       snapdragon "^0.8.1"
       to-regex "^3.0.1"
+  
+  expect@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/expect/-/expect-24.7.1.tgz#d91defbab4e627470a152feaf35b3c31aa1c7c14"
+    integrity sha512-mGfvMTPduksV3xoI0xur56pQsg2vJjNf5+a+bXOjqCkiCBbmCayrBbHS/75y9K430cfqyocPr2ZjiNiRx4SRKw==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      ansi-styles "^3.2.0"
+      jest-get-type "^24.3.0"
+      jest-matcher-utils "^24.7.0"
+      jest-message-util "^24.7.1"
+      jest-regex-util "^24.3.0"
   
   extend-shallow@^2.0.1:
     version "2.0.1"
@@ -688,6 +1643,11 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
     integrity sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=
   
+  extend@~3.0.2:
+    version "3.0.2"
+    resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+    integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+  
   external-editor@^2.0.4, external-editor@^2.1.0:
     version "2.2.0"
     resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -695,6 +1655,15 @@ Lockfile:
     dependencies:
       chardet "^0.4.0"
       iconv-lite "^0.4.17"
+      tmp "^0.0.33"
+  
+  external-editor@^3.0.3:
+    version "3.0.3"
+    resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+    integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+    dependencies:
+      chardet "^0.7.0"
+      iconv-lite "^0.4.24"
       tmp "^0.0.33"
   
   extglob@^2.0.4:
@@ -711,7 +1680,22 @@ Lockfile:
       snapdragon "^0.8.1"
       to-regex "^3.0.1"
   
-  fast-glob@^2.2.6:
+  extsprintf@1.3.0:
+    version "1.3.0"
+    resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+    integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+  
+  extsprintf@^1.2.0:
+    version "1.4.0"
+    resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+    integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+  
+  fast-deep-equal@^2.0.1:
+    version "2.0.1"
+    resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+    integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+  
+  fast-glob@^2.0.2, fast-glob@^2.2.6:
     version "2.2.6"
     resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.6.tgz#a5d5b697ec8deda468d85a74035290a025a95295"
     integrity sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==
@@ -723,12 +1707,37 @@ Lockfile:
       merge2 "^1.2.3"
       micromatch "^3.1.10"
   
+  fast-json-stable-stringify@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+    integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+  
+  fast-levenshtein@~2.0.4:
+    version "2.0.6"
+    resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+    integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  
+  fb-watchman@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
+    integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
+    dependencies:
+      bser "^2.0.0"
+  
   figures@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
     integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
     dependencies:
       escape-string-regexp "^1.0.5"
+  
+  fileset@^2.0.3:
+    version "2.0.3"
+    resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
+    integrity sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=
+    dependencies:
+      glob "^7.0.3"
+      minimatch "^3.0.3"
   
   fill-range@^4.0.0:
     version "4.0.0"
@@ -747,10 +1756,22 @@ Lockfile:
     dependencies:
       locate-path "^2.0.0"
   
+  find-up@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+    integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+    dependencies:
+      locate-path "^3.0.0"
+  
   for-in@^1.0.2:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
     integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+  
+  forever-agent@~0.6.1:
+    version "0.6.1"
+    resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+    integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
   
   form-data@1.0.0-rc3:
     version "1.0.0-rc3"
@@ -760,6 +1781,15 @@ Lockfile:
       async "^1.4.0"
       combined-stream "^1.0.5"
       mime-types "^2.1.3"
+  
+  form-data@~2.3.2:
+    version "2.3.3"
+    resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+    integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+    dependencies:
+      asynckit "^0.4.0"
+      combined-stream "^1.0.6"
+      mime-types "^2.1.12"
   
   formidable@~1.0.14:
     version "1.0.17"
@@ -791,10 +1821,34 @@ Lockfile:
       jsonfile "^4.0.0"
       universalify "^0.1.0"
   
+  fs-extra@^7.0.0:
+    version "7.0.1"
+    resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+    integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+    dependencies:
+      graceful-fs "^4.1.2"
+      jsonfile "^4.0.0"
+      universalify "^0.1.0"
+  
+  fs-minipass@^1.2.5:
+    version "1.2.5"
+    resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+    integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+    dependencies:
+      minipass "^2.2.1"
+  
   fs.realpath@^1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
     integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+  
+  fsevents@^1.2.7:
+    version "1.2.8"
+    resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.8.tgz#57ea5320f762cd4696e5e8e87120eccc8b11cacf"
+    integrity sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==
+    dependencies:
+      nan "^2.12.1"
+      node-pre-gyp "^0.12.0"
   
   function-bind@^1.1.1:
     version "1.1.1"
@@ -806,15 +1860,48 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
     integrity sha1-THbsL/CsGjap3M+aAN+GIweNTtg=
   
+  gauge@~2.7.3:
+    version "2.7.4"
+    resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+    integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+    dependencies:
+      aproba "^1.0.3"
+      console-control-strings "^1.0.0"
+      has-unicode "^2.0.0"
+      object-assign "^4.1.0"
+      signal-exit "^3.0.0"
+      string-width "^1.0.1"
+      strip-ansi "^3.0.1"
+      wide-align "^1.1.0"
+  
+  get-caller-file@^1.0.1:
+    version "1.0.3"
+    resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
+    integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+  
   get-stream@^3.0.0:
     version "3.0.0"
     resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
     integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
   
+  get-stream@^4.0.0:
+    version "4.1.0"
+    resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+    integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+    dependencies:
+      pump "^3.0.0"
+  
   get-value@^2.0.2, get-value@^2.0.3, get-value@^2.0.6:
     version "2.0.6"
     resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
     integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+  
+  getpass@^0.1.1:
+    version "0.1.7"
+    resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+    integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+    dependencies:
+      assert-plus "^1.0.0"
   
   glob-parent@^3.1.0:
     version "3.1.0"
@@ -829,7 +1916,7 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
     integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
   
-  glob@^7.0.3, glob@^7.1.1, glob@^7.1.3:
+  glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     version "7.1.3"
     resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
     integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -841,6 +1928,11 @@ Lockfile:
       once "^1.3.0"
       path-is-absolute "^1.0.0"
   
+  globals@^11.1.0:
+    version "11.11.0"
+    resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
+    integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
+  
   globby@^6.1.0:
     version "6.1.0"
     resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
@@ -851,6 +1943,19 @@ Lockfile:
       object-assign "^4.0.1"
       pify "^2.0.0"
       pinkie-promise "^2.0.0"
+  
+  globby@^8.0.1:
+    version "8.0.2"
+    resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
+    integrity sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==
+    dependencies:
+      array-union "^1.0.1"
+      dir-glob "2.0.0"
+      fast-glob "^2.0.2"
+      glob "^7.1.2"
+      ignore "^3.3.5"
+      pify "^3.0.0"
+      slash "^1.0.0"
   
   globby@^9.2.0:
     version "9.2.0"
@@ -866,10 +1971,39 @@ Lockfile:
       pify "^4.0.1"
       slash "^2.0.0"
   
-  graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
     version "4.1.15"
     resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
     integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+  
+  growly@^1.3.0:
+    version "1.3.0"
+    resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+    integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+  
+  handlebars@^4.1.0:
+    version "4.1.2"
+    resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+    integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+    dependencies:
+      neo-async "^2.6.0"
+      optimist "^0.6.1"
+      source-map "^0.6.1"
+    optionalDependencies:
+      uglify-js "^3.1.4"
+  
+  har-schema@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+    integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+  
+  har-validator@~5.1.0:
+    version "5.1.3"
+    resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+    integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+    dependencies:
+      ajv "^6.5.5"
+      har-schema "^2.0.0"
   
   has-flag@^3.0.0:
     version "3.0.0"
@@ -880,6 +2014,11 @@ Lockfile:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
     integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+  
+  has-unicode@^2.0.0:
+    version "2.0.1"
+    resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+    integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
   
   has-value@^0.3.1:
     version "0.3.1"
@@ -924,17 +2063,58 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
     integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
   
-  iconv-lite@^0.4.17:
+  html-encoding-sniffer@^1.0.2:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+    integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
+    dependencies:
+      whatwg-encoding "^1.0.1"
+  
+  http-signature@~1.2.0:
+    version "1.2.0"
+    resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+    integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+    dependencies:
+      assert-plus "^1.0.0"
+      jsprim "^1.2.2"
+      sshpk "^1.7.0"
+  
+  iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
     version "0.4.24"
     resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
     integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
     dependencies:
       safer-buffer ">= 2.1.2 < 3"
   
+  ignore-walk@^3.0.1:
+    version "3.0.1"
+    resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+    integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+    dependencies:
+      minimatch "^3.0.4"
+  
+  ignore@^3.3.5:
+    version "3.3.10"
+    resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+    integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+  
   ignore@^4.0.3:
     version "4.0.6"
     resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
     integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+  
+  import-local@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/import-local/-/import-local-2.0.0.tgz#55070be38a5993cf18ef6db7e961f5bee5c5a09d"
+    integrity sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==
+    dependencies:
+      pkg-dir "^3.0.0"
+      resolve-cwd "^2.0.0"
+  
+  imurmurhash@^0.1.4:
+    version "0.1.4"
+    resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+    integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
   
   indent-string@^3.0.0:
     version "3.2.0"
@@ -949,10 +2129,15 @@ Lockfile:
       once "^1.3.0"
       wrappy "1"
   
-  inherits@2, inherits@~2.0.1:
+  inherits@2, inherits@~2.0.1, inherits@~2.0.3:
     version "2.0.3"
     resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
     integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+  
+  ini@~1.3.0:
+    version "1.3.5"
+    resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+    integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
   
   inquirer-autocomplete-prompt@^1.0.1:
     version "1.0.1"
@@ -1013,6 +2198,68 @@ Lockfile:
       strip-ansi "^4.0.0"
       through "^2.3.6"
   
+  inquirer@^6.2.0:
+    version "6.2.2"
+    resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
+    integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
+    dependencies:
+      ansi-escapes "^3.2.0"
+      chalk "^2.4.2"
+      cli-cursor "^2.1.0"
+      cli-width "^2.0.0"
+      external-editor "^3.0.3"
+      figures "^2.0.0"
+      lodash "^4.17.11"
+      mute-stream "0.0.7"
+      run-async "^2.2.0"
+      rxjs "^6.4.0"
+      string-width "^2.1.0"
+      strip-ansi "^5.0.0"
+      through "^2.3.6"
+  
+  inquirer@^6.3.1:
+    version "6.3.1"
+    resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+    integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+    dependencies:
+      ansi-escapes "^3.2.0"
+      chalk "^2.4.2"
+      cli-cursor "^2.1.0"
+      cli-width "^2.0.0"
+      external-editor "^3.0.3"
+      figures "^2.0.0"
+      lodash "^4.17.11"
+      mute-stream "0.0.7"
+      run-async "^2.2.0"
+      rxjs "^6.4.0"
+      string-width "^2.1.0"
+      strip-ansi "^5.1.0"
+      through "^2.3.6"
+  
+  install-packages@^0.2.5:
+    version "0.2.5"
+    resolved "https://registry.yarnpkg.com/install-packages/-/install-packages-0.2.5.tgz#b50bfe3c2a36081850ba0d8c661fa6f11caeaa9e"
+    integrity sha512-K+rnxKcem/Aa5+FPInrjoGLbsalo41ELmxay9sGpDvaFjGglbEGOaB/NefquzWGzMxPfJoaep7cYd0OEG9AOsA==
+    dependencies:
+      chalk "^2.3.2"
+      command-exists "^1.2.6"
+      cross-spawn "^4.0.2"
+      joycon "^2.1.1"
+      parse-package-name "^0.1.0"
+      resolve "^1.7.1"
+  
+  invariant@^2.2.4:
+    version "2.2.4"
+    resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+    integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+    dependencies:
+      loose-envify "^1.0.0"
+  
+  invert-kv@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+    integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+  
   is-accessor-descriptor@^0.1.6:
     version "0.1.6"
     resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -1041,6 +2288,13 @@ Lockfile:
     version "1.1.4"
     resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
     integrity sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==
+  
+  is-ci@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+    integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+    dependencies:
+      ci-info "^2.0.0"
   
   is-data-descriptor@^0.1.4:
     version "0.1.4"
@@ -1096,10 +2350,22 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
     integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
   
+  is-fullwidth-code-point@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+    integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+    dependencies:
+      number-is-nan "^1.0.0"
+  
   is-fullwidth-code-point@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
     integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+  
+  is-generator-fn@^2.0.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+    integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
   
   is-glob@^3.1.0:
     version "3.1.0"
@@ -1115,12 +2381,36 @@ Lockfile:
     dependencies:
       is-extglob "^2.1.1"
   
+  is-module@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+    integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+  
   is-number@^3.0.0:
     version "3.0.0"
     resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
     integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
     dependencies:
       kind-of "^3.0.2"
+  
+  is-path-cwd@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+    integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
+  
+  is-path-in-cwd@^1.0.0:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+    integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
+    dependencies:
+      is-path-inside "^1.0.0"
+  
+  is-path-inside@^1.0.0:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+    integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+    dependencies:
+      path-is-inside "^1.0.1"
   
   is-plain-obj@^1.1.0:
     version "1.1.0"
@@ -1158,17 +2448,27 @@ Lockfile:
     dependencies:
       has-symbols "^1.0.0"
   
+  is-typedarray@~1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+    integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+  
   is-windows@^1.0.2:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
     integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+  
+  is-wsl@^1.1.0:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+    integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
   
   isarray@0.0.1:
     version "0.0.1"
     resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
     integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
   
-  isarray@1.0.0:
+  isarray@1.0.0, isarray@~1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
     integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -1190,10 +2490,526 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
     integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
   
+  isstream@~0.1.2:
+    version "0.1.2"
+    resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+    integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+  
+  istanbul-api@^2.1.1:
+    version "2.1.5"
+    resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-2.1.5.tgz#697b95ec69856c278aacafc0f86ee7392338d5b5"
+    integrity sha512-meYk1BwDp59Pfse1TvPrkKYgVqAufbdBLEVoqvu/hLLKSaQ054ZTksbNepyc223tMnWdm6AdK2URIJJRqdP87g==
+    dependencies:
+      async "^2.6.1"
+      compare-versions "^3.2.1"
+      fileset "^2.0.3"
+      istanbul-lib-coverage "^2.0.4"
+      istanbul-lib-hook "^2.0.6"
+      istanbul-lib-instrument "^3.2.0"
+      istanbul-lib-report "^2.0.7"
+      istanbul-lib-source-maps "^3.0.5"
+      istanbul-reports "^2.2.3"
+      js-yaml "^3.13.0"
+      make-dir "^2.1.0"
+      minimatch "^3.0.4"
+      once "^1.4.0"
+  
+  istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.4:
+    version "2.0.4"
+    resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#927a354005d99dd43a24607bb8b33fd4e9aca1ad"
+    integrity sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==
+  
+  istanbul-lib-hook@^2.0.6:
+    version "2.0.6"
+    resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz#5baa6067860a38290aef038b389068b225b01b7d"
+    integrity sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==
+    dependencies:
+      append-transform "^1.0.0"
+  
+  istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.2.0:
+    version "3.2.0"
+    resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz#c549208da8a793f6622257a2da83e0ea96ae6a93"
+    integrity sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==
+    dependencies:
+      "@babel/generator" "^7.0.0"
+      "@babel/parser" "^7.0.0"
+      "@babel/template" "^7.0.0"
+      "@babel/traverse" "^7.0.0"
+      "@babel/types" "^7.0.0"
+      istanbul-lib-coverage "^2.0.4"
+      semver "^6.0.0"
+  
+  istanbul-lib-report@^2.0.7:
+    version "2.0.7"
+    resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz#370d80d433c4dbc7f58de63618f49599c74bd954"
+    integrity sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==
+    dependencies:
+      istanbul-lib-coverage "^2.0.4"
+      make-dir "^2.1.0"
+      supports-color "^6.0.0"
+  
+  istanbul-lib-source-maps@^3.0.1, istanbul-lib-source-maps@^3.0.5:
+    version "3.0.5"
+    resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz#1d9ee9d94d2633f15611ee7aae28f9cac6d1aeb9"
+    integrity sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==
+    dependencies:
+      debug "^4.1.1"
+      istanbul-lib-coverage "^2.0.4"
+      make-dir "^2.1.0"
+      rimraf "^2.6.2"
+      source-map "^0.6.1"
+  
+  istanbul-reports@^2.2.3:
+    version "2.2.3"
+    resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.3.tgz#14e0d00ecbfa9387757999cf36599b88e9f2176e"
+    integrity sha512-T6EbPuc8Cb620LWAYyZ4D8SSn06dY9i1+IgUX2lTH8gbwflMc9Obd33zHTyNX653ybjpamAHS9toKS3E6cGhTw==
+    dependencies:
+      handlebars "^4.1.0"
+  
+  jest-changed-files@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.7.0.tgz#39d723a11b16ed7b373ac83adc76a69464b0c4fa"
+    integrity sha512-33BgewurnwSfJrW7T5/ZAXGE44o7swLslwh8aUckzq2e17/2Os1V0QU506ZNik3hjs8MgnEMKNkcud442NCDTw==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      execa "^1.0.0"
+      throat "^4.0.0"
+  
+  jest-cli@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.7.1.tgz#6093a539073b6f4953145abeeb9709cd621044f1"
+    integrity sha512-32OBoSCVPzcTslGFl6yVCMzB2SqX3IrWwZCY5mZYkb0D2WsogmU3eV2o8z7+gRQa4o4sZPX/k7GU+II7CxM6WQ==
+    dependencies:
+      "@jest/core" "^24.7.1"
+      "@jest/test-result" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      chalk "^2.0.1"
+      exit "^0.1.2"
+      import-local "^2.0.0"
+      is-ci "^2.0.0"
+      jest-config "^24.7.1"
+      jest-util "^24.7.1"
+      jest-validate "^24.7.0"
+      prompts "^2.0.1"
+      realpath-native "^1.1.0"
+      yargs "^12.0.2"
+  
+  jest-config@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-24.7.1.tgz#6c1dd4db82a89710a3cf66bdba97827c9a1cf052"
+    integrity sha512-8FlJNLI+X+MU37j7j8RE4DnJkvAghXmBWdArVzypW6WxfGuxiL/CCkzBg0gHtXhD2rxla3IMOSUAHylSKYJ83g==
+    dependencies:
+      "@babel/core" "^7.1.0"
+      "@jest/test-sequencer" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      babel-jest "^24.7.1"
+      chalk "^2.0.1"
+      glob "^7.1.1"
+      jest-environment-jsdom "^24.7.1"
+      jest-environment-node "^24.7.1"
+      jest-get-type "^24.3.0"
+      jest-jasmine2 "^24.7.1"
+      jest-regex-util "^24.3.0"
+      jest-resolve "^24.7.1"
+      jest-util "^24.7.1"
+      jest-validate "^24.7.0"
+      micromatch "^3.1.10"
+      pretty-format "^24.7.0"
+      realpath-native "^1.1.0"
+  
+  jest-diff@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.7.0.tgz#5d862899be46249754806f66e5729c07fcb3580f"
+    integrity sha512-ULQZ5B1lWpH70O4xsANC4tf4Ko6RrpwhE3PtG6ERjMg1TiYTC2Wp4IntJVGro6a8HG9luYHhhmF4grF0Pltckg==
+    dependencies:
+      chalk "^2.0.1"
+      diff-sequences "^24.3.0"
+      jest-get-type "^24.3.0"
+      pretty-format "^24.7.0"
+  
+  jest-docblock@^24.3.0:
+    version "24.3.0"
+    resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.3.0.tgz#b9c32dac70f72e4464520d2ba4aec02ab14db5dd"
+    integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
+    dependencies:
+      detect-newline "^2.1.0"
+  
+  jest-each@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.7.1.tgz#fcc7dda4147c28430ad9fb6dc7211cd17ab54e74"
+    integrity sha512-4fsS8fEfLa3lfnI1Jw6NxjhyRTgfpuOVTeUZZFyVYqeTa4hPhr2YkToUhouuLTrL2eMGOfpbdMyRx0GQ/VooKA==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      chalk "^2.0.1"
+      jest-get-type "^24.3.0"
+      jest-util "^24.7.1"
+      pretty-format "^24.7.0"
+  
+  jest-environment-jsdom@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-24.7.1.tgz#a40e004b4458ebeb8a98082df135fd501b9fbbd6"
+    integrity sha512-Gnhb+RqE2JuQGb3kJsLF8vfqjt3PHKSstq4Xc8ic+ax7QKo4Z0RWGucU3YV+DwKR3T9SYc+3YCUQEJs8r7+Jxg==
+    dependencies:
+      "@jest/environment" "^24.7.1"
+      "@jest/fake-timers" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      jest-mock "^24.7.0"
+      jest-util "^24.7.1"
+      jsdom "^11.5.1"
+  
+  jest-environment-node@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.7.1.tgz#fa2c047a31522a48038d26ee4f7c8fd9c1ecfe12"
+    integrity sha512-GJJQt1p9/C6aj6yNZMvovZuxTUd+BEJprETdvTKSb4kHcw4mFj8777USQV0FJoJ4V3djpOwA5eWyPwfq//PFBA==
+    dependencies:
+      "@jest/environment" "^24.7.1"
+      "@jest/fake-timers" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      jest-mock "^24.7.0"
+      jest-util "^24.7.1"
+  
+  jest-get-type@^24.3.0:
+    version "24.3.0"
+    resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.3.0.tgz#582cfd1a4f91b5cdad1d43d2932f816d543c65da"
+    integrity sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==
+  
+  jest-haste-map@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-24.7.1.tgz#772e215cd84080d4bbcb759cfb668ad649a21471"
+    integrity sha512-g0tWkzjpHD2qa03mTKhlydbmmYiA2KdcJe762SbfFo/7NIMgBWAA0XqQlApPwkWOF7Cxoi/gUqL0i6DIoLpMBw==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      anymatch "^2.0.0"
+      fb-watchman "^2.0.0"
+      graceful-fs "^4.1.15"
+      invariant "^2.2.4"
+      jest-serializer "^24.4.0"
+      jest-util "^24.7.1"
+      jest-worker "^24.6.0"
+      micromatch "^3.1.10"
+      sane "^4.0.3"
+      walker "^1.0.7"
+    optionalDependencies:
+      fsevents "^1.2.7"
+  
+  jest-in-case@^1.0.2:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/jest-in-case/-/jest-in-case-1.0.2.tgz#56744b5af33222bd0abab70cf919f1d170ab75cc"
+    integrity sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=
+  
+  jest-jasmine2@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz#01398686dabe46553716303993f3be62e5d9d818"
+    integrity sha512-Y/9AOJDV1XS44wNwCaThq4Pw3gBPiOv/s6NcbOAkVRRUEPu+36L2xoPsqQXsDrxoBerqeyslpn2TpCI8Zr6J2w==
+    dependencies:
+      "@babel/traverse" "^7.1.0"
+      "@jest/environment" "^24.7.1"
+      "@jest/test-result" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      chalk "^2.0.1"
+      co "^4.6.0"
+      expect "^24.7.1"
+      is-generator-fn "^2.0.0"
+      jest-each "^24.7.1"
+      jest-matcher-utils "^24.7.0"
+      jest-message-util "^24.7.1"
+      jest-runtime "^24.7.1"
+      jest-snapshot "^24.7.1"
+      jest-util "^24.7.1"
+      pretty-format "^24.7.0"
+      throat "^4.0.0"
+  
+  jest-leak-detector@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.7.0.tgz#323ff93ed69be12e898f5b040952f08a94288ff9"
+    integrity sha512-zV0qHKZGXtmPVVzT99CVEcHE9XDf+8LwiE0Ob7jjezERiGVljmqKFWpV2IkG+rkFIEUHFEkMiICu7wnoPM/RoQ==
+    dependencies:
+      pretty-format "^24.7.0"
+  
+  jest-matcher-utils@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.7.0.tgz#bbee1ff37bc8b2e4afcaabc91617c1526af4bcd4"
+    integrity sha512-158ieSgk3LNXeUhbVJYRXyTPSCqNgVXOp/GT7O94mYd3pk/8+odKTyR1JLtNOQSPzNi8NFYVONtvSWA/e1RDXg==
+    dependencies:
+      chalk "^2.0.1"
+      jest-diff "^24.7.0"
+      jest-get-type "^24.3.0"
+      pretty-format "^24.7.0"
+  
+  jest-message-util@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.7.1.tgz#f1dc3a6c195647096a99d0f1dadbc447ae547018"
+    integrity sha512-dk0gqVtyqezCHbcbk60CdIf+8UHgD+lmRHifeH3JRcnAqh4nEyPytSc9/L1+cQyxC+ceaeP696N4ATe7L+omcg==
+    dependencies:
+      "@babel/code-frame" "^7.0.0"
+      "@jest/test-result" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      "@types/stack-utils" "^1.0.1"
+      chalk "^2.0.1"
+      micromatch "^3.1.10"
+      slash "^2.0.0"
+      stack-utils "^1.0.1"
+  
+  jest-mock@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.7.0.tgz#e49ce7262c12d7f5897b0d8af77f6db8e538023b"
+    integrity sha512-6taW4B4WUcEiT2V9BbOmwyGuwuAFT2G8yghF7nyNW1/2gq5+6aTqSPcS9lS6ArvEkX55vbPAS/Jarx5LSm4Fng==
+    dependencies:
+      "@jest/types" "^24.7.0"
+  
+  jest-pnp-resolver@^1.2.1:
+    version "1.2.1"
+    resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
+    integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
+  
+  jest-regex-util@^24.3.0:
+    version "24.3.0"
+    resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.3.0.tgz#d5a65f60be1ae3e310d5214a0307581995227b36"
+    integrity sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==
+  
+  jest-resolve-dependencies@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-24.7.1.tgz#cf93bbef26999488a96a2b2012f9fe7375aa378f"
+    integrity sha512-2Eyh5LJB2liNzfk4eo7bD1ZyBbqEJIyyrFtZG555cSWW9xVHxII2NuOkSl1yUYTAYCAmM2f2aIT5A7HzNmubyg==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      jest-regex-util "^24.3.0"
+      jest-snapshot "^24.7.1"
+  
+  jest-resolve@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-24.7.1.tgz#e4150198299298380a75a9fd55043fa3b9b17fde"
+    integrity sha512-Bgrc+/UUZpGJ4323sQyj85hV9d+ANyPNu6XfRDUcyFNX1QrZpSoM0kE4Mb2vZMAYTJZsBFzYe8X1UaOkOELSbw==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      browser-resolve "^1.11.3"
+      chalk "^2.0.1"
+      jest-pnp-resolver "^1.2.1"
+      realpath-native "^1.1.0"
+  
+  jest-runner@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-24.7.1.tgz#41c8a02a06aa23ea82d8bffd69d7fa98d32f85bf"
+    integrity sha512-aNFc9liWU/xt+G9pobdKZ4qTeG/wnJrJna3VqunziDNsWT3EBpmxXZRBMKCsNMyfy+A/XHiV+tsMLufdsNdgCw==
+    dependencies:
+      "@jest/console" "^24.7.1"
+      "@jest/environment" "^24.7.1"
+      "@jest/test-result" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      chalk "^2.4.2"
+      exit "^0.1.2"
+      graceful-fs "^4.1.15"
+      jest-config "^24.7.1"
+      jest-docblock "^24.3.0"
+      jest-haste-map "^24.7.1"
+      jest-jasmine2 "^24.7.1"
+      jest-leak-detector "^24.7.0"
+      jest-message-util "^24.7.1"
+      jest-resolve "^24.7.1"
+      jest-runtime "^24.7.1"
+      jest-util "^24.7.1"
+      jest-worker "^24.6.0"
+      source-map-support "^0.5.6"
+      throat "^4.0.0"
+  
+  jest-runtime@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-24.7.1.tgz#2ffd70b22dd03a5988c0ab9465c85cdf5d25c597"
+    integrity sha512-0VAbyBy7tll3R+82IPJpf6QZkokzXPIS71aDeqh+WzPRXRCNz6StQ45otFariPdJ4FmXpDiArdhZrzNAC3sj6A==
+    dependencies:
+      "@jest/console" "^24.7.1"
+      "@jest/environment" "^24.7.1"
+      "@jest/source-map" "^24.3.0"
+      "@jest/transform" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      "@types/yargs" "^12.0.2"
+      chalk "^2.0.1"
+      exit "^0.1.2"
+      glob "^7.1.3"
+      graceful-fs "^4.1.15"
+      jest-config "^24.7.1"
+      jest-haste-map "^24.7.1"
+      jest-message-util "^24.7.1"
+      jest-mock "^24.7.0"
+      jest-regex-util "^24.3.0"
+      jest-resolve "^24.7.1"
+      jest-snapshot "^24.7.1"
+      jest-util "^24.7.1"
+      jest-validate "^24.7.0"
+      realpath-native "^1.1.0"
+      slash "^2.0.0"
+      strip-bom "^3.0.0"
+      yargs "^12.0.2"
+  
+  jest-serializer@^24.4.0:
+    version "24.4.0"
+    resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-24.4.0.tgz#f70c5918c8ea9235ccb1276d232e459080588db3"
+    integrity sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==
+  
+  jest-snapshot@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-24.7.1.tgz#bd5a35f74aedff070975e9e9c90024f082099568"
+    integrity sha512-8Xk5O4p+JsZZn4RCNUS3pxA+ORKpEKepE+a5ejIKrId9CwrVN0NY+vkqEkXqlstA5NMBkNahXkR/4qEBy0t5yA==
+    dependencies:
+      "@babel/types" "^7.0.0"
+      "@jest/types" "^24.7.0"
+      chalk "^2.0.1"
+      expect "^24.7.1"
+      jest-diff "^24.7.0"
+      jest-matcher-utils "^24.7.0"
+      jest-message-util "^24.7.1"
+      jest-resolve "^24.7.1"
+      mkdirp "^0.5.1"
+      natural-compare "^1.4.0"
+      pretty-format "^24.7.0"
+      semver "^5.5.0"
+  
+  jest-util@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.7.1.tgz#b4043df57b32a23be27c75a2763d8faf242038ff"
+    integrity sha512-/KilOue2n2rZ5AnEBYoxOXkeTu6vi7cjgQ8MXEkih0oeAXT6JkS3fr7/j8+engCjciOU1Nq5loMSKe0A1oeX0A==
+    dependencies:
+      "@jest/console" "^24.7.1"
+      "@jest/fake-timers" "^24.7.1"
+      "@jest/source-map" "^24.3.0"
+      "@jest/test-result" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      callsites "^3.0.0"
+      chalk "^2.0.1"
+      graceful-fs "^4.1.15"
+      is-ci "^2.0.0"
+      mkdirp "^0.5.1"
+      slash "^2.0.0"
+      source-map "^0.6.0"
+  
+  jest-validate@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.7.0.tgz#70007076f338528ee1b1c8a8258b1b0bb982508d"
+    integrity sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      camelcase "^5.0.0"
+      chalk "^2.0.1"
+      jest-get-type "^24.3.0"
+      leven "^2.1.0"
+      pretty-format "^24.7.0"
+  
+  jest-watcher@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.7.1.tgz#e161363d7f3f4e1ef3d389b7b3a0aad247b673f5"
+    integrity sha512-Wd6TepHLRHVKLNPacEsBwlp9raeBIO+01xrN24Dek4ggTS8HHnOzYSFnvp+6MtkkJ3KfMzy220KTi95e2rRkrw==
+    dependencies:
+      "@jest/test-result" "^24.7.1"
+      "@jest/types" "^24.7.0"
+      "@types/yargs" "^12.0.9"
+      ansi-escapes "^3.0.0"
+      chalk "^2.0.1"
+      jest-util "^24.7.1"
+      string-length "^2.0.0"
+  
+  jest-worker@24.0.0:
+    version "24.0.0"
+    resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.0.0.tgz#3d3483b077bf04f412f47654a27bba7e947f8b6d"
+    integrity sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==
+    dependencies:
+      merge-stream "^1.0.1"
+      supports-color "^6.1.0"
+  
+  jest-worker@^24.6.0:
+    version "24.6.0"
+    resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.6.0.tgz#7f81ceae34b7cde0c9827a6980c35b7cdc0161b3"
+    integrity sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==
+    dependencies:
+      merge-stream "^1.0.1"
+      supports-color "^6.1.0"
+  
+  jest@^24.7.1:
+    version "24.7.1"
+    resolved "https://registry.yarnpkg.com/jest/-/jest-24.7.1.tgz#0d94331cf510c75893ee32f87d7321d5bf8f2501"
+    integrity sha512-AbvRar5r++izmqo5gdbAjTeA6uNRGoNRuj5vHB0OnDXo2DXWZJVuaObiGgtlvhKb+cWy2oYbQSfxv7Q7GjnAtA==
+    dependencies:
+      import-local "^2.0.0"
+      jest-cli "^24.7.1"
+  
+  joycon@^2.1.1:
+    version "2.2.5"
+    resolved "https://registry.yarnpkg.com/joycon/-/joycon-2.2.5.tgz#8d4cf4cbb2544d7b7583c216fcdfec19f6be1615"
+    integrity sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
+  
+  "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+    version "4.0.0"
+    resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+    integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+  
+  js-yaml@^3.13.0:
+    version "3.13.1"
+    resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+    integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+    dependencies:
+      argparse "^1.0.7"
+      esprima "^4.0.0"
+  
+  jsbn@~0.1.0:
+    version "0.1.1"
+    resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+    integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+  
+  jsdom@^11.5.1:
+    version "11.12.0"
+    resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+    integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
+    dependencies:
+      abab "^2.0.0"
+      acorn "^5.5.3"
+      acorn-globals "^4.1.0"
+      array-equal "^1.0.0"
+      cssom ">= 0.3.2 < 0.4.0"
+      cssstyle "^1.0.0"
+      data-urls "^1.0.0"
+      domexception "^1.0.1"
+      escodegen "^1.9.1"
+      html-encoding-sniffer "^1.0.2"
+      left-pad "^1.3.0"
+      nwsapi "^2.0.7"
+      parse5 "4.0.0"
+      pn "^1.1.0"
+      request "^2.87.0"
+      request-promise-native "^1.0.5"
+      sax "^1.2.4"
+      symbol-tree "^3.2.2"
+      tough-cookie "^2.3.4"
+      w3c-hr-time "^1.0.1"
+      webidl-conversions "^4.0.2"
+      whatwg-encoding "^1.0.3"
+      whatwg-mimetype "^2.1.0"
+      whatwg-url "^6.4.1"
+      ws "^5.2.0"
+      xml-name-validator "^3.0.0"
+  
+  jsesc@^2.5.1:
+    version "2.5.2"
+    resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+    integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+  
   json-parse-better-errors@^1.0.1:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
     integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+  
+  json-schema-traverse@^0.4.1:
+    version "0.4.1"
+    resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+    integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+  
+  json-schema@0.2.3:
+    version "0.2.3"
+    resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+    integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+  
+  json-stringify-safe@~5.0.1:
+    version "5.0.1"
+    resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+    integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
   
   json5@^2.1.0:
     version "2.1.0"
@@ -1215,6 +3031,16 @@ Lockfile:
     integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
     optionalDependencies:
       graceful-fs "^4.1.6"
+  
+  jsprim@^1.2.2:
+    version "1.4.1"
+    resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+    integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+    dependencies:
+      assert-plus "1.0.0"
+      extsprintf "1.3.0"
+      json-schema "0.2.3"
+      verror "1.10.0"
   
   kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
     version "3.2.2"
@@ -1239,6 +3065,36 @@ Lockfile:
     version "6.0.2"
     resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
     integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+  
+  kleur@^3.0.2:
+    version "3.0.3"
+    resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+    integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+  
+  lcid@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+    integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
+    dependencies:
+      invert-kv "^2.0.0"
+  
+  left-pad@^1.3.0:
+    version "1.3.0"
+    resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
+    integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
+  
+  leven@^2.1.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+    integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
+  
+  levn@~0.3.0:
+    version "0.3.0"
+    resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+    integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+    dependencies:
+      prelude-ls "~1.1.2"
+      type-check "~0.3.2"
   
   load-json-file@^2.0.0:
     version "2.0.0"
@@ -1268,6 +3124,29 @@ Lockfile:
       p-locate "^2.0.0"
       path-exists "^3.0.0"
   
+  locate-path@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+    integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+    dependencies:
+      p-locate "^3.0.0"
+      path-exists "^3.0.0"
+  
+  lodash.isempty@^4.4.0:
+    version "4.4.0"
+    resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+    integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
+  
+  lodash.omitby@^4.6.0:
+    version "4.6.0"
+    resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
+    integrity sha1-XBX/R1StVVAWtTwEExHo8HkgR5E=
+  
+  lodash.sortby@^4.7.0:
+    version "4.7.0"
+    resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+    integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+  
   lodash@^3.10.1:
     version "3.10.1"
     resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -1277,6 +3156,13 @@ Lockfile:
     version "4.17.11"
     resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
     integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+  
+  loose-envify@^1.0.0:
+    version "1.4.0"
+    resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+    integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+    dependencies:
+      js-tokens "^3.0.0 || ^4.0.0"
   
   loud-rejection@^1.0.0:
     version "1.6.0"
@@ -1294,12 +3180,41 @@ Lockfile:
       pseudomap "^1.0.2"
       yallist "^2.1.2"
   
+  magic-string@^0.25.1, magic-string@^0.25.2:
+    version "0.25.2"
+    resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.2.tgz#139c3a729515ec55e96e69e82a11fe890a293ad9"
+    integrity sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==
+    dependencies:
+      sourcemap-codec "^1.4.4"
+  
   make-dir@^1.0.0:
     version "1.3.0"
     resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
     integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
     dependencies:
       pify "^3.0.0"
+  
+  make-dir@^2.1.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+    integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+    dependencies:
+      pify "^4.0.1"
+      semver "^5.6.0"
+  
+  makeerror@1.0.x:
+    version "1.0.11"
+    resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+    integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+    dependencies:
+      tmpl "1.0.x"
+  
+  map-age-cleaner@^0.1.1:
+    version "0.1.3"
+    resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+    integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+    dependencies:
+      p-defer "^1.0.0"
   
   map-cache@^0.2.2:
     version "0.2.2"
@@ -1323,6 +3238,15 @@ Lockfile:
     dependencies:
       object-visit "^1.0.0"
   
+  mem@^4.0.0:
+    version "4.3.0"
+    resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+    integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+    dependencies:
+      map-age-cleaner "^0.1.1"
+      mimic-fn "^2.0.0"
+      p-is-promise "^2.0.0"
+  
   meow@^4.0.0:
     version "4.0.1"
     resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz#d48598f6f4b1472f35bf6317a95945ace347f975"
@@ -1338,6 +3262,28 @@ Lockfile:
       redent "^2.0.0"
       trim-newlines "^2.0.0"
   
+  meow@^5.0.0:
+    version "5.0.0"
+    resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+    integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
+    dependencies:
+      camelcase-keys "^4.0.0"
+      decamelize-keys "^1.0.0"
+      loud-rejection "^1.0.0"
+      minimist-options "^3.0.1"
+      normalize-package-data "^2.3.4"
+      read-pkg-up "^3.0.0"
+      redent "^2.0.0"
+      trim-newlines "^2.0.0"
+      yargs-parser "^10.0.0"
+  
+  merge-stream@^1.0.1:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+    integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
+    dependencies:
+      readable-stream "^2.0.1"
+  
   merge2@^1.2.3:
     version "1.2.3"
     resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
@@ -1348,7 +3294,7 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
     integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
   
-  micromatch@^3.1.10:
+  micromatch@^3.1.10, micromatch@^3.1.4:
     version "3.1.10"
     resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
     integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -1367,10 +3313,22 @@ Lockfile:
       snapdragon "^0.8.1"
       to-regex "^3.0.2"
   
+  mime-db@1.40.0:
+    version "1.40.0"
+    resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+    integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+  
   mime-db@~1.38.0:
     version "1.38.0"
     resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
     integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
+  
+  mime-types@^2.1.12, mime-types@~2.1.19:
+    version "2.1.24"
+    resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+    integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+    dependencies:
+      mime-db "1.40.0"
   
   mime-types@^2.1.3:
     version "2.1.22"
@@ -1389,7 +3347,12 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
     integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
   
-  minimatch@^3.0.0, minimatch@^3.0.4:
+  mimic-fn@^2.0.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+    integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+  
+  minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
     version "3.0.4"
     resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
     integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -1409,10 +3372,30 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
     integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
   
-  minimist@^1.1.3, minimist@^1.2.0:
+  minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
     version "1.2.0"
     resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
     integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  
+  minimist@~0.0.1:
+    version "0.0.10"
+    resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+    integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+  
+  minipass@^2.2.1, minipass@^2.3.4:
+    version "2.3.5"
+    resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+    integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+    dependencies:
+      safe-buffer "^5.1.2"
+      yallist "^3.0.0"
+  
+  minizlib@^1.1.1:
+    version "1.2.1"
+    resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+    integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
+    dependencies:
+      minipass "^2.2.1"
   
   mixin-deep@^1.2.0:
     version "1.3.1"
@@ -1422,7 +3405,7 @@ Lockfile:
       for-in "^1.0.2"
       is-extendable "^1.0.1"
   
-  mkdirp@~0.5.0:
+  mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
     version "0.5.1"
     resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
     integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -1433,6 +3416,11 @@ Lockfile:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
     integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+  
+  ms@^2.1.1:
+    version "2.1.1"
+    resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+    integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
   
   multimatch@^2.1.0:
     version "2.1.0"
@@ -1448,6 +3436,11 @@ Lockfile:
     version "0.0.7"
     resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
     integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+  
+  nan@^2.12.1:
+    version "2.13.2"
+    resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+    integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
   
   nanomatch@^1.2.9:
     version "1.2.13"
@@ -1466,6 +3459,80 @@ Lockfile:
       snapdragon "^0.8.1"
       to-regex "^3.0.1"
   
+  natural-compare@^1.4.0:
+    version "1.4.0"
+    resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+    integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+  
+  needle@^2.2.1:
+    version "2.3.0"
+    resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.0.tgz#ce3fea21197267bacb310705a7bbe24f2a3a3492"
+    integrity sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==
+    dependencies:
+      debug "^4.1.0"
+      iconv-lite "^0.4.4"
+      sax "^1.2.4"
+  
+  neo-async@^2.6.0:
+    version "2.6.0"
+    resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
+    integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
+  
+  nice-try@^1.0.4:
+    version "1.0.5"
+    resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+    integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+  
+  node-addon-api@^1.6.0:
+    version "1.6.3"
+    resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.3.tgz#3998d4593e2dca2ea82114670a4eb003386a9fe1"
+    integrity sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg==
+  
+  node-int64@^0.4.0:
+    version "0.4.0"
+    resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+    integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+  
+  node-modules-regexp@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+    integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+  
+  node-notifier@^5.2.1:
+    version "5.4.0"
+    resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.0.tgz#7b455fdce9f7de0c63538297354f3db468426e6a"
+    integrity sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==
+    dependencies:
+      growly "^1.3.0"
+      is-wsl "^1.1.0"
+      semver "^5.5.0"
+      shellwords "^0.1.1"
+      which "^1.3.0"
+  
+  node-pre-gyp@^0.12.0:
+    version "0.12.0"
+    resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+    integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
+    dependencies:
+      detect-libc "^1.0.2"
+      mkdirp "^0.5.1"
+      needle "^2.2.1"
+      nopt "^4.0.1"
+      npm-packlist "^1.1.6"
+      npmlog "^4.0.2"
+      rc "^1.2.7"
+      rimraf "^2.6.1"
+      semver "^5.3.0"
+      tar "^4"
+  
+  nopt@^4.0.1:
+    version "4.0.1"
+    resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+    integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
+    dependencies:
+      abbrev "1"
+      osenv "^0.1.4"
+  
   normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     version "2.5.0"
     resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -1475,6 +3542,26 @@ Lockfile:
       resolve "^1.10.0"
       semver "2 || 3 || 4 || 5"
       validate-npm-package-license "^3.0.1"
+  
+  normalize-path@^2.1.1:
+    version "2.1.1"
+    resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+    integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+    dependencies:
+      remove-trailing-separator "^1.0.1"
+  
+  npm-bundled@^1.0.1:
+    version "1.0.6"
+    resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
+    integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+  
+  npm-packlist@^1.1.6:
+    version "1.4.1"
+    resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
+    integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
+    dependencies:
+      ignore-walk "^3.0.1"
+      npm-bundled "^1.0.1"
   
   npm-path@^2.0.2, npm-path@^2.0.3:
     version "2.0.4"
@@ -1511,7 +3598,32 @@ Lockfile:
       npm-path "^2.0.2"
       which "^1.2.10"
   
-  object-assign@^4.0.1:
+  npmlog@^4.0.2:
+    version "4.1.2"
+    resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+    integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+    dependencies:
+      are-we-there-yet "~1.1.2"
+      console-control-strings "~1.1.0"
+      gauge "~2.7.3"
+      set-blocking "~2.0.0"
+  
+  number-is-nan@^1.0.0:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+    integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+  
+  nwsapi@^2.0.7:
+    version "2.1.3"
+    resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.3.tgz#25f3a5cec26c654f7376df6659cdf84b99df9558"
+    integrity sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==
+  
+  oauth-sign@~0.9.0:
+    version "0.9.0"
+    resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+    integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+  
+  object-assign@^4.0.1, object-assign@^4.1.0:
     version "4.1.1"
     resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
     integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -1537,6 +3649,14 @@ Lockfile:
     dependencies:
       isobject "^3.0.0"
   
+  object.getownpropertydescriptors@^2.0.3:
+    version "2.0.3"
+    resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
+    integrity sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=
+    dependencies:
+      define-properties "^1.1.2"
+      es-abstract "^1.5.1"
+  
   object.pick@^1.3.0:
     version "1.3.0"
     resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
@@ -1544,7 +3664,7 @@ Lockfile:
     dependencies:
       isobject "^3.0.1"
   
-  once@^1.3.0:
+  once@^1.3.0, once@^1.3.1, once@^1.4.0:
     version "1.4.0"
     resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
     integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -1558,20 +3678,79 @@ Lockfile:
     dependencies:
       mimic-fn "^1.0.0"
   
-  os-tmpdir@~1.0.2:
+  optimist@^0.6.1:
+    version "0.6.1"
+    resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+    integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
+    dependencies:
+      minimist "~0.0.1"
+      wordwrap "~0.0.2"
+  
+  optionator@^0.8.1:
+    version "0.8.2"
+    resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+    integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+    dependencies:
+      deep-is "~0.1.3"
+      fast-levenshtein "~2.0.4"
+      levn "~0.3.0"
+      prelude-ls "~1.1.2"
+      type-check "~0.3.2"
+      wordwrap "~1.0.0"
+  
+  os-homedir@^1.0.0:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+    integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+  
+  os-locale@^3.0.0:
+    version "3.1.0"
+    resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+    integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
+    dependencies:
+      execa "^1.0.0"
+      lcid "^2.0.0"
+      mem "^4.0.0"
+  
+  os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
     integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+  
+  osenv@^0.1.4:
+    version "0.1.5"
+    resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+    integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
+    dependencies:
+      os-homedir "^1.0.0"
+      os-tmpdir "^1.0.0"
   
   outdent@^0.5.0:
     version "0.5.0"
     resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.5.0.tgz#9e10982fdc41492bb473ad13840d22f9655be2ff"
     integrity sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==
   
+  p-defer@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+    integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+  
+  p-each-series@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
+    integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
+    dependencies:
+      p-reduce "^1.0.0"
+  
   p-finally@^1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
     integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+  
+  p-is-promise@^2.0.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+    integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
   
   p-limit@^1.1.0:
     version "1.3.0"
@@ -1580,6 +3759,13 @@ Lockfile:
     dependencies:
       p-try "^1.0.0"
   
+  p-limit@^2.0.0:
+    version "2.2.0"
+    resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+    integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+    dependencies:
+      p-try "^2.0.0"
+  
   p-locate@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -1587,10 +3773,32 @@ Lockfile:
     dependencies:
       p-limit "^1.1.0"
   
+  p-locate@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+    integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+    dependencies:
+      p-limit "^2.0.0"
+  
+  p-map@^1.1.1:
+    version "1.2.0"
+    resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+    integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+  
+  p-reduce@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
+    integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+  
   p-try@^1.0.0:
     version "1.0.0"
     resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
     integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+  
+  p-try@^2.0.0:
+    version "2.2.0"
+    resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+    integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
   
   parse-json@^2.2.0:
     version "2.2.0"
@@ -1606,6 +3814,16 @@ Lockfile:
     dependencies:
       error-ex "^1.3.1"
       json-parse-better-errors "^1.0.1"
+  
+  parse-package-name@^0.1.0:
+    version "0.1.0"
+    resolved "https://registry.yarnpkg.com/parse-package-name/-/parse-package-name-0.1.0.tgz#3f44dd838feb4c2be4bf318bae4477d7706bade4"
+    integrity sha1-P0Tdg4/rTCvkvzGLrkR313BrreQ=
+  
+  parse5@4.0.0:
+    version "4.0.0"
+    resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+    integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
   
   pascalcase@^0.1.1:
     version "0.1.1"
@@ -1627,12 +3845,12 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
     integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
   
-  path-is-inside@^1.0.2:
+  path-is-inside@^1.0.1, path-is-inside@^1.0.2:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
     integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
   
-  path-key@^2.0.0:
+  path-key@^2.0.0, path-key@^2.0.1:
     version "2.0.1"
     resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
     integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -1655,6 +3873,11 @@ Lockfile:
     integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
     dependencies:
       pify "^3.0.0"
+  
+  performance-now@^2.1.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+    integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
   
   pify@^2.0.0:
     version "2.3.0"
@@ -1683,6 +3906,20 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
     integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
   
+  pirates@^4.0.1:
+    version "4.0.1"
+    resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
+    integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+    dependencies:
+      node-modules-regexp "^1.0.0"
+  
+  pkg-dir@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+    integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+    dependencies:
+      find-up "^3.0.0"
+  
   pkg-up@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
@@ -1690,15 +3927,80 @@ Lockfile:
     dependencies:
       find-up "^2.1.0"
   
+  pn@^1.1.0:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+    integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+  
   posix-character-classes@^0.1.0:
     version "0.1.1"
     resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
     integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
   
-  prettier@^1.14.3:
+  preconstruct@^0.0.54:
+    version "0.0.54"
+    resolved "https://registry.yarnpkg.com/preconstruct/-/preconstruct-0.0.54.tgz#a8b9e03e30da4540cfbf25f4eea0e27a29111f66"
+    integrity sha512-GvQZ9+vEo+gpZqI9Rlzfb+/7UugWgw77xGfs0tMPOuJgPzMIaai1xky3mQbMxIwu4yRcZ0C1XybCX5naiZOadg==
+    dependencies:
+      "@babel/code-frame" "^7.0.0"
+      "@babel/core" "^7.1.2"
+      "@babel/plugin-proposal-class-properties" "^7.3.4"
+      "@babel/plugin-transform-flow-strip-types" "^7.4.0"
+      "@babel/plugin-transform-runtime" "^7.2.0"
+      builtin-modules "^3.0.0"
+      chalk "^2.3.2"
+      dataloader "^1.4.0"
+      deasync "^0.1.14"
+      del "^3.0.0"
+      diff "^4.0.1"
+      fast-deep-equal "^2.0.1"
+      fs-extra "^7.0.0"
+      globby "^8.0.1"
+      inquirer "^6.2.0"
+      install-packages "^0.2.5"
+      jest-worker "24.0.0"
+      lodash.isempty "^4.4.0"
+      lodash.omitby "^4.6.0"
+      magic-string "^0.25.1"
+      meow "^5.0.0"
+      ms "^2.1.1"
+      p-limit "^2.0.0"
+      prettier "^1.15.3"
+      resolve "^1.10.0"
+      resolve-from "^4.0.0"
+      rollup "^1.0.0"
+      rollup-plugin-alias "^1.4.0"
+      rollup-plugin-commonjs "^9.1.3"
+      rollup-plugin-node-resolve "^4.0.0"
+      rollup-plugin-replace "^2.0.0"
+      rollup-pluginutils "^2.6.0"
+      sarcastic "^1.5.0"
+      terser "^3.14.1"
+  
+  prelude-ls@~1.1.2:
+    version "1.1.2"
+    resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+    integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+  
+  prettier@^1.14.3, prettier@^1.15.3:
     version "1.16.4"
     resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
     integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+  
+  pretty-format@^24.7.0:
+    version "24.7.0"
+    resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
+    integrity sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==
+    dependencies:
+      "@jest/types" "^24.7.0"
+      ansi-regex "^4.0.0"
+      ansi-styles "^3.2.0"
+      react-is "^16.8.4"
+  
+  process-nextick-args@~2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+    integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
   
   project-bin-path@^1.1.0:
     version "1.1.1"
@@ -1714,6 +4016,14 @@ Lockfile:
     dependencies:
       cross-spawn "^5.1.0"
   
+  prompts@^2.0.1:
+    version "2.0.4"
+    resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.0.4.tgz#179f9d4db3128b9933aa35f93a800d8fce76a682"
+    integrity sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==
+    dependencies:
+      kleur "^3.0.2"
+      sisteransi "^1.0.0"
+  
   protochain@^1.0.5:
     version "1.0.5"
     resolved "https://registry.yarnpkg.com/protochain/-/protochain-1.0.5.tgz#991c407e99de264aadf8f81504b5e7faf7bfa260"
@@ -1724,15 +4034,58 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
     integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
   
+  psl@^1.1.24, psl@^1.1.28:
+    version "1.1.31"
+    resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+    integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
+  
+  pump@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+    integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+    dependencies:
+      end-of-stream "^1.1.0"
+      once "^1.3.1"
+  
+  punycode@^1.4.1:
+    version "1.4.1"
+    resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+    integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+  
+  punycode@^2.1.0, punycode@^2.1.1:
+    version "2.1.1"
+    resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+    integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  
   qs@2.3.3:
     version "2.3.3"
     resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
     integrity sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=
   
+  qs@~6.5.2:
+    version "6.5.2"
+    resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+    integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  
   quick-lru@^1.0.0:
     version "1.1.0"
     resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
     integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
+  
+  rc@^1.2.7:
+    version "1.2.8"
+    resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+    integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+    dependencies:
+      deep-extend "^0.6.0"
+      ini "~1.3.0"
+      minimist "^1.2.0"
+      strip-json-comments "~2.0.1"
+  
+  react-is@^16.8.4:
+    version "16.8.6"
+    resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+    integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
   
   read-cmd-shim@^1.0.1:
     version "1.0.1"
@@ -1747,6 +4100,14 @@ Lockfile:
     integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
     dependencies:
       find-up "^2.0.0"
+      read-pkg "^3.0.0"
+  
+  read-pkg-up@^4.0.0:
+    version "4.0.0"
+    resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
+    integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
+    dependencies:
+      find-up "^3.0.0"
       read-pkg "^3.0.0"
   
   read-pkg@^2.0.0:
@@ -1777,6 +4138,26 @@ Lockfile:
       isarray "0.0.1"
       string_decoder "~0.10.x"
   
+  readable-stream@^2.0.1, readable-stream@^2.0.6:
+    version "2.3.6"
+    resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+    integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+    dependencies:
+      core-util-is "~1.0.0"
+      inherits "~2.0.3"
+      isarray "~1.0.0"
+      process-nextick-args "~2.0.0"
+      safe-buffer "~5.1.1"
+      string_decoder "~1.1.1"
+      util-deprecate "~1.0.1"
+  
+  realpath-native@^1.1.0:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
+    integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
+    dependencies:
+      util.promisify "^1.0.0"
+  
   redent@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
@@ -1803,6 +4184,11 @@ Lockfile:
       extend-shallow "^3.0.2"
       safe-regex "^1.1.0"
   
+  remove-trailing-separator@^1.0.1:
+    version "1.1.0"
+    resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+    integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+  
   repeat-element@^1.1.2:
     version "1.1.3"
     resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
@@ -1812,6 +4198,63 @@ Lockfile:
     version "1.6.1"
     resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
     integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+  
+  request-promise-core@1.1.2:
+    version "1.1.2"
+    resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+    integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
+    dependencies:
+      lodash "^4.17.11"
+  
+  request-promise-native@^1.0.5:
+    version "1.0.7"
+    resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
+    integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
+    dependencies:
+      request-promise-core "1.1.2"
+      stealthy-require "^1.1.1"
+      tough-cookie "^2.3.3"
+  
+  request@^2.87.0:
+    version "2.88.0"
+    resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+    integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+    dependencies:
+      aws-sign2 "~0.7.0"
+      aws4 "^1.8.0"
+      caseless "~0.12.0"
+      combined-stream "~1.0.6"
+      extend "~3.0.2"
+      forever-agent "~0.6.1"
+      form-data "~2.3.2"
+      har-validator "~5.1.0"
+      http-signature "~1.2.0"
+      is-typedarray "~1.0.0"
+      isstream "~0.1.2"
+      json-stringify-safe "~5.0.1"
+      mime-types "~2.1.19"
+      oauth-sign "~0.9.0"
+      performance-now "^2.1.0"
+      qs "~6.5.2"
+      safe-buffer "^5.1.2"
+      tough-cookie "~2.4.3"
+      tunnel-agent "^0.6.0"
+      uuid "^3.3.2"
+  
+  require-directory@^2.1.1:
+    version "2.1.1"
+    resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+    integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+  
+  require-main-filename@^1.0.1:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+    integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
+  
+  require-main-filename@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+    integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
   
   resolve-cwd@^2.0.0:
     version "2.0.0"
@@ -1825,12 +4268,22 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
     integrity sha1-six699nWiBvItuZTM17rywoYh0g=
   
+  resolve-from@^4.0.0:
+    version "4.0.0"
+    resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+    integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+  
   resolve-url@^0.2.1:
     version "0.2.1"
     resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
     integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
   
-  resolve@^1.10.0:
+  resolve@1.1.7:
+    version "1.1.7"
+    resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+    integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+  
+  resolve@^1.10.0, resolve@^1.3.2, resolve@^1.7.1, resolve@^1.8.1:
     version "1.10.0"
     resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
     integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -1850,12 +4303,69 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
     integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
   
-  rimraf@^2.6.1, rimraf@^2.6.3:
+  rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
     version "2.6.3"
     resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
     integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
     dependencies:
       glob "^7.1.3"
+  
+  rollup-plugin-alias@^1.4.0:
+    version "1.5.1"
+    resolved "https://registry.yarnpkg.com/rollup-plugin-alias/-/rollup-plugin-alias-1.5.1.tgz#80cce3a967befda5b09c86abc14a043a78035b46"
+    integrity sha512-pQTYBRNfLedoVOO7AYHNegIavEIp4jKTga5jUi1r//KYgHKGWgG4qJXYhbcWKt2k1FwGlR5wCYoY+IFkme0t4A==
+    dependencies:
+      slash "^2.0.0"
+  
+  rollup-plugin-commonjs@^9.1.3:
+    version "9.3.4"
+    resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
+    integrity sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==
+    dependencies:
+      estree-walker "^0.6.0"
+      magic-string "^0.25.2"
+      resolve "^1.10.0"
+      rollup-pluginutils "^2.6.0"
+  
+  rollup-plugin-node-resolve@^4.0.0:
+    version "4.2.2"
+    resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.2.tgz#590962b8568d8f7361c2b434e10bd8cb91556615"
+    integrity sha512-fkTHihF4Tzc95ZotKJNZZgxZPzslj+twk6UNWSBn3ln1mSV55atjsi7CDODdw/NNlteaf/jjjvrAj62p7OQjaQ==
+    dependencies:
+      "@types/resolve" "0.0.8"
+      builtin-modules "^3.0.0"
+      is-module "^1.0.0"
+      resolve "^1.10.0"
+  
+  rollup-plugin-replace@^2.0.0:
+    version "2.2.0"
+    resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+    integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
+    dependencies:
+      magic-string "^0.25.2"
+      rollup-pluginutils "^2.6.0"
+  
+  rollup-pluginutils@^2.6.0:
+    version "2.6.0"
+    resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz#203706edd43dfafeaebc355d7351119402fc83ad"
+    integrity sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==
+    dependencies:
+      estree-walker "^0.6.0"
+      micromatch "^3.1.10"
+  
+  rollup@^1.0.0:
+    version "1.9.3"
+    resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.9.3.tgz#c898fd562dff3165470fc5de9b5e191d50f944b2"
+    integrity sha512-20iIOjee5n3H6W6CXsVdYs2xw86j4l+LQLM6yACynt+YJCwkqaYNHAjQ/dhVBIKsFpHwPqHamn/GHq+3Zp8ybQ==
+    dependencies:
+      "@types/estree" "0.0.39"
+      "@types/node" "^11.13.2"
+      acorn "^6.1.1"
+  
+  rsvp@^4.8.4:
+    version "4.8.4"
+    resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
+    integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==
   
   run-async@^2.2.0, run-async@^2.3.0:
     version "2.3.0"
@@ -1883,6 +4393,18 @@ Lockfile:
     dependencies:
       symbol-observable "1.0.1"
   
+  rxjs@^6.4.0:
+    version "6.4.0"
+    resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+    integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+    dependencies:
+      tslib "^1.9.0"
+  
+  safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+    version "5.1.2"
+    resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+    integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+  
   safe-regex@^1.1.0:
     version "1.1.0"
     resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -1890,15 +4412,45 @@ Lockfile:
     dependencies:
       ret "~0.1.10"
   
-  "safer-buffer@>= 2.1.2 < 3":
+  "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
     version "2.1.2"
     resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
     integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
   
-  "semver@2 || 3 || 4 || 5", semver@^5.4.1:
+  sane@^4.0.3:
+    version "4.1.0"
+    resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
+    integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
+    dependencies:
+      "@cnakazawa/watch" "^1.0.3"
+      anymatch "^2.0.0"
+      capture-exit "^2.0.0"
+      exec-sh "^0.3.2"
+      execa "^1.0.0"
+      fb-watchman "^2.0.0"
+      micromatch "^3.1.4"
+      minimist "^1.1.1"
+      walker "~1.0.5"
+  
+  sarcastic@^1.5.0:
+    version "1.5.0"
+    resolved "https://registry.yarnpkg.com/sarcastic/-/sarcastic-1.5.0.tgz#1e87e75bb64e856d3f34d1f5a391c3abecf8c7c1"
+    integrity sha512-j7zmeNbABvOGXzt11WIm7nITPJ0exX/IL0sV9GZHNSsrFEjadfK5Z3GfBEelc6/VoEp17i/JEw3UuzyJNvgZNw==
+  
+  sax@^1.2.4:
+    version "1.2.4"
+    resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+    integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+  
+  "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
     version "5.7.0"
     resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
     integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+  
+  semver@^6.0.0:
+    version "6.0.0"
+    resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+    integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
   
   serializerr@^1.0.3:
     version "1.0.3"
@@ -1906,6 +4458,11 @@ Lockfile:
     integrity sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=
     dependencies:
       protochain "^1.0.5"
+  
+  set-blocking@^2.0.0, set-blocking@~2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+    integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
   
   set-value@^0.4.3:
     version "0.4.3"
@@ -1939,10 +4496,20 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
     integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
   
+  shellwords@^0.1.1:
+    version "0.1.1"
+    resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+    integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+  
   signal-exit@^3.0.0, signal-exit@^3.0.2:
     version "3.0.2"
     resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
     integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+  
+  sisteransi@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
+    integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
   
   slash@^1.0.0:
     version "1.0.0"
@@ -2017,15 +4584,33 @@ Lockfile:
       source-map-url "^0.4.0"
       urix "^0.1.0"
   
+  source-map-support@^0.5.6, source-map-support@~0.5.10:
+    version "0.5.12"
+    resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+    integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+    dependencies:
+      buffer-from "^1.0.0"
+      source-map "^0.6.0"
+  
   source-map-url@^0.4.0:
     version "0.4.0"
     resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
     integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
   
-  source-map@^0.5.6:
+  source-map@^0.5.0, source-map@^0.5.6:
     version "0.5.7"
     resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
     integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+  
+  source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+    version "0.6.1"
+    resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+    integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+  
+  sourcemap-codec@^1.4.4:
+    version "1.4.4"
+    resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz#c63ea927c029dd6bd9a2b7fa03b3fec02ad56e9f"
+    integrity sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==
   
   spdx-correct@^3.0.0:
     version "3.1.0"
@@ -2060,6 +4645,31 @@ Lockfile:
     dependencies:
       extend-shallow "^3.0.0"
   
+  sprintf-js@~1.0.2:
+    version "1.0.3"
+    resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+    integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+  
+  sshpk@^1.7.0:
+    version "1.16.1"
+    resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+    integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+    dependencies:
+      asn1 "~0.2.3"
+      assert-plus "^1.0.0"
+      bcrypt-pbkdf "^1.0.0"
+      dashdash "^1.12.0"
+      ecc-jsbn "~0.1.1"
+      getpass "^0.1.1"
+      jsbn "~0.1.0"
+      safer-buffer "^2.0.2"
+      tweetnacl "~0.14.0"
+  
+  stack-utils@^1.0.1:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+    integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+  
   static-extend@^0.1.1:
     version "0.1.2"
     resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -2068,7 +4678,29 @@ Lockfile:
       define-property "^0.2.5"
       object-copy "^0.1.0"
   
-  string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+  stealthy-require@^1.1.1:
+    version "1.1.1"
+    resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+    integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+  
+  string-length@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
+    integrity sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=
+    dependencies:
+      astral-regex "^1.0.0"
+      strip-ansi "^4.0.0"
+  
+  string-width@^1.0.1:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+    integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+    dependencies:
+      code-point-at "^1.0.0"
+      is-fullwidth-code-point "^1.0.0"
+      strip-ansi "^3.0.0"
+  
+  "string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     version "2.1.1"
     resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
     integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -2081,12 +4713,33 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
     integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
   
+  string_decoder@~1.1.1:
+    version "1.1.1"
+    resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+    integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+    dependencies:
+      safe-buffer "~5.1.0"
+  
+  strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+    version "3.0.1"
+    resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+    integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+    dependencies:
+      ansi-regex "^2.0.0"
+  
   strip-ansi@^4.0.0:
     version "4.0.0"
     resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
     integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
     dependencies:
       ansi-regex "^3.0.0"
+  
+  strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+    version "5.2.0"
+    resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+    integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+    dependencies:
+      ansi-regex "^4.1.0"
   
   strip-bom@^3.0.0:
     version "3.0.0"
@@ -2102,6 +4755,11 @@ Lockfile:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
     integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
+  
+  strip-json-comments@~2.0.1:
+    version "2.0.1"
+    resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+    integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
   
   style-dictionary@^2.7.0:
     version "2.7.0"
@@ -2141,15 +4799,40 @@ Lockfile:
     dependencies:
       has-flag "^3.0.0"
   
+  supports-color@^6.0.0, supports-color@^6.1.0:
+    version "6.1.0"
+    resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+    integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+    dependencies:
+      has-flag "^3.0.0"
+  
   symbol-observable@1.0.1:
     version "1.0.1"
     resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
     integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
   
+  symbol-tree@^3.2.2:
+    version "3.2.2"
+    resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+    integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+  
   sync-exec@^0.6.2:
     version "0.6.2"
     resolved "https://registry.yarnpkg.com/sync-exec/-/sync-exec-0.6.2.tgz#717d22cc53f0ce1def5594362f3a89a2ebb91105"
     integrity sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=
+  
+  tar@^4:
+    version "4.4.8"
+    resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+    integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+    dependencies:
+      chownr "^1.1.1"
+      fs-minipass "^1.2.5"
+      minipass "^2.3.4"
+      minizlib "^1.1.1"
+      mkdirp "^0.5.0"
+      safe-buffer "^5.1.2"
+      yallist "^3.0.2"
   
   task-graph-runner@^1.0.1:
     version "1.0.2"
@@ -2182,6 +4865,30 @@ Lockfile:
     dependencies:
       execa "^0.7.0"
   
+  terser@^3.14.1:
+    version "3.17.0"
+    resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
+    integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
+    dependencies:
+      commander "^2.19.0"
+      source-map "~0.6.1"
+      source-map-support "~0.5.10"
+  
+  test-exclude@^5.2.2:
+    version "5.2.2"
+    resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.2.tgz#7322f8ab037b0b93ad2aab35fe9068baf997a4c4"
+    integrity sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==
+    dependencies:
+      glob "^7.1.3"
+      minimatch "^3.0.4"
+      read-pkg-up "^4.0.0"
+      require-main-filename "^2.0.0"
+  
+  throat@^4.0.0:
+    version "4.1.0"
+    resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+    integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+  
   through@^2.3.6:
     version "2.3.8"
     resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -2198,6 +4905,16 @@ Lockfile:
     integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
     dependencies:
       os-tmpdir "~1.0.2"
+  
+  tmpl@1.0.x:
+    version "1.0.4"
+    resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+    integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+  
+  to-fast-properties@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+    integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
   
   to-object-path@^0.3.0:
     version "0.3.0"
@@ -2224,10 +4941,62 @@ Lockfile:
       regex-not "^1.0.2"
       safe-regex "^1.1.0"
   
+  tough-cookie@^2.3.3, tough-cookie@^2.3.4:
+    version "2.5.0"
+    resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+    integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+    dependencies:
+      psl "^1.1.28"
+      punycode "^2.1.1"
+  
+  tough-cookie@~2.4.3:
+    version "2.4.3"
+    resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+    integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+    dependencies:
+      psl "^1.1.24"
+      punycode "^1.4.1"
+  
+  tr46@^1.0.1:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+    integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+    dependencies:
+      punycode "^2.1.0"
+  
   trim-newlines@^2.0.0:
     version "2.0.0"
     resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
     integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
+  
+  trim-right@^1.0.1:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+    integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+  
+  tslib@^1.9.0:
+    version "1.9.3"
+    resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+    integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+  
+  tunnel-agent@^0.6.0:
+    version "0.6.0"
+    resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+    integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+    dependencies:
+      safe-buffer "^5.0.1"
+  
+  tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+    version "0.14.5"
+    resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+    integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+  
+  type-check@~0.3.2:
+    version "0.3.2"
+    resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+    integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+    dependencies:
+      prelude-ls "~1.1.2"
   
   typeable-promisify@^2.0.1:
     version "2.0.1"
@@ -2247,6 +5016,14 @@ Lockfile:
     integrity sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=
     dependencies:
       typewise-core "^1.2.0"
+  
+  uglify-js@^3.1.4:
+    version "3.5.6"
+    resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.6.tgz#8a5f8a06ee7415ac1fa302f4623bc7344b553da4"
+    integrity sha512-YDKRX8F0Y+Jr7LhoVk0n4G7ltR3Y7qFAj+DtVBthlOgCcIj1hyMigCfousVfn9HKmvJ+qiFlLDwaHx44/e5ZKw==
+    dependencies:
+      commander "~2.20.0"
+      source-map "~0.6.1"
   
   union-value@^0.2.3:
     version "0.2.4"
@@ -2281,6 +5058,13 @@ Lockfile:
       has-value "^0.3.1"
       isobject "^3.0.0"
   
+  uri-js@^4.2.2:
+    version "4.2.2"
+    resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+    integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+    dependencies:
+      punycode "^2.1.0"
+  
   urix@^0.1.0:
     version "0.1.0"
     resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -2291,7 +5075,20 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
     integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
   
-  uuid@^3.0.1, uuid@^3.1.0:
+  util-deprecate@~1.0.1:
+    version "1.0.2"
+    resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+    integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+  
+  util.promisify@^1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+    integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
+    dependencies:
+      define-properties "^1.1.2"
+      object.getownpropertydescriptors "^2.0.3"
+  
+  uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
     version "3.3.2"
     resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
     integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -2304,12 +5101,82 @@ Lockfile:
       spdx-correct "^3.0.0"
       spdx-expression-parse "^3.0.0"
   
-  which@^1.2.10, which@^1.2.9:
+  verror@1.10.0:
+    version "1.10.0"
+    resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+    integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+    dependencies:
+      assert-plus "^1.0.0"
+      core-util-is "1.0.2"
+      extsprintf "^1.2.0"
+  
+  w3c-hr-time@^1.0.1:
+    version "1.0.1"
+    resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+    integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
+    dependencies:
+      browser-process-hrtime "^0.1.2"
+  
+  walker@^1.0.7, walker@~1.0.5:
+    version "1.0.7"
+    resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+    integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
+    dependencies:
+      makeerror "1.0.x"
+  
+  webidl-conversions@^4.0.2:
+    version "4.0.2"
+    resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+    integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+  
+  whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+    version "1.0.5"
+    resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+    integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+    dependencies:
+      iconv-lite "0.4.24"
+  
+  whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+    version "2.3.0"
+    resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+    integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+  
+  whatwg-url@^6.4.1:
+    version "6.5.0"
+    resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+    integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
+    dependencies:
+      lodash.sortby "^4.7.0"
+      tr46 "^1.0.1"
+      webidl-conversions "^4.0.2"
+  
+  whatwg-url@^7.0.0:
+    version "7.0.0"
+    resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+    integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
+    dependencies:
+      lodash.sortby "^4.7.0"
+      tr46 "^1.0.1"
+      webidl-conversions "^4.0.2"
+  
+  which-module@^2.0.0:
+    version "2.0.0"
+    resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+    integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+  
+  which@^1.2.10, which@^1.2.9, which@^1.3.0:
     version "1.3.1"
     resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
     integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
     dependencies:
       isexe "^2.0.0"
+  
+  wide-align@^1.1.0:
+    version "1.1.3"
+    resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+    integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+    dependencies:
+      string-width "^1.0.2 || 2"
   
   widest-line@^2.0.0:
     version "2.0.1"
@@ -2318,15 +5185,97 @@ Lockfile:
     dependencies:
       string-width "^2.1.1"
   
+  wordwrap@~0.0.2:
+    version "0.0.3"
+    resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
+    integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
+  
+  wordwrap@~1.0.0:
+    version "1.0.0"
+    resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+    integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+  
+  wrap-ansi@^2.0.0:
+    version "2.1.0"
+    resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+    integrity sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=
+    dependencies:
+      string-width "^1.0.1"
+      strip-ansi "^3.0.1"
+  
   wrappy@1:
     version "1.0.2"
     resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
     integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   
+  write-file-atomic@2.4.1:
+    version "2.4.1"
+    resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
+    integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
+    dependencies:
+      graceful-fs "^4.1.11"
+      imurmurhash "^0.1.4"
+      signal-exit "^3.0.2"
+  
+  ws@^5.2.0:
+    version "5.2.2"
+    resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+    integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+    dependencies:
+      async-limiter "~1.0.0"
+  
+  xml-name-validator@^3.0.0:
+    version "3.0.0"
+    resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+    integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+  
+  "y18n@^3.2.1 || ^4.0.0":
+    version "4.0.0"
+    resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+    integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  
   yallist@^2.1.2:
     version "2.1.2"
     resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
     integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+  
+  yallist@^3.0.0, yallist@^3.0.2:
+    version "3.0.3"
+    resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+    integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+  
+  yargs-parser@^10.0.0:
+    version "10.1.0"
+    resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+    integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+    dependencies:
+      camelcase "^4.1.0"
+  
+  yargs-parser@^11.1.1:
+    version "11.1.1"
+    resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+    integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+    dependencies:
+      camelcase "^5.0.0"
+      decamelize "^1.2.0"
+  
+  yargs@^12.0.2:
+    version "12.0.5"
+    resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+    integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+    dependencies:
+      cliui "^4.0.0"
+      decamelize "^1.2.0"
+      find-up "^3.0.0"
+      get-caller-file "^1.0.1"
+      os-locale "^3.0.0"
+      require-directory "^2.1.1"
+      require-main-filename "^1.0.1"
+      set-blocking "^2.0.0"
+      string-width "^2.0.0"
+      which-module "^2.0.0"
+      y18n "^3.2.1 || ^4.0.0"
+      yargs-parser "^11.1.1"
   
   yarn@^1.9.4:
     version "1.15.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,6 +1372,11 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 diff@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
@@ -1447,7 +1452,7 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1657,6 +1662,20 @@ figures@^2.0.0:
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
+
+filename-reserved-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
+  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-2.1.0.tgz#88faf495fb1b47abfd612300002a16228c677ee9"
+  integrity sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==
+  dependencies:
+    filename-reserved-regex "^2.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
 
 fileset@^2.0.3:
   version "2.0.3"
@@ -2544,6 +2563,16 @@ jest-config@^24.7.1:
     pretty-format "^24.7.0"
     realpath-native "^1.1.0"
 
+jest-diff@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.6.0.tgz#1500f3f16e850bb3d71233408089be099f610c7d"
+  integrity sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.6.0"
+
 jest-diff@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.7.0.tgz#5d862899be46249754806f66e5729c07fcb3580f"
@@ -2594,6 +2623,21 @@ jest-environment-node@^24.7.1:
     "@jest/types" "^24.7.0"
     jest-mock "^24.7.0"
     jest-util "^24.7.1"
+
+jest-file-snapshot@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/jest-file-snapshot/-/jest-file-snapshot-0.3.6.tgz#392b86adfed45f695d0d3184d2752df9da5264f3"
+  integrity sha512-/+otGi8yC109jp6Kg4UVaF0MJ2iE4V07jgbvh/+velJa0F35zjMHI7aUpqyphakBwcNgl+ndMix5NpRZOXJ/OA==
+  dependencies:
+    chalk "^2.4.1"
+    filenamify "^2.1.0"
+    jest-diff "^23.6.0"
+    mkdirp "^0.5.1"
+
+jest-get-type@^22.1.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
 
 jest-get-type@^24.3.0:
   version "24.3.0"
@@ -3914,6 +3958,14 @@ prettier@^1.14.3, prettier@^1.15.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
+pretty-format@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
+  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 pretty-format@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
@@ -4688,6 +4740,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-outer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
+  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
+  dependencies:
+    escape-string-regexp "^1.0.2"
+
 style-dictionary@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-2.7.0.tgz#9576257a6829a8c7481a661a70bb8c81d2307599"
@@ -4895,6 +4954,13 @@ trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
   integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
+
+trim-repeated@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
+  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
+  dependencies:
+    escape-string-regexp "^1.0.2"
 
 trim-right@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,11 +1372,6 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
-diff@^3.2.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
 diff@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
@@ -1452,7 +1447,7 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1662,20 +1657,6 @@ figures@^2.0.0:
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
-
-filename-reserved-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
-  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
-
-filenamify@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-2.1.0.tgz#88faf495fb1b47abfd612300002a16228c677ee9"
-  integrity sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==
-  dependencies:
-    filename-reserved-regex "^2.0.0"
-    strip-outer "^1.0.0"
-    trim-repeated "^1.0.0"
 
 fileset@^2.0.3:
   version "2.0.3"
@@ -2563,16 +2544,6 @@ jest-config@^24.7.1:
     pretty-format "^24.7.0"
     realpath-native "^1.1.0"
 
-jest-diff@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.6.0.tgz#1500f3f16e850bb3d71233408089be099f610c7d"
-  integrity sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==
-  dependencies:
-    chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.6.0"
-
 jest-diff@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.7.0.tgz#5d862899be46249754806f66e5729c07fcb3580f"
@@ -2623,21 +2594,6 @@ jest-environment-node@^24.7.1:
     "@jest/types" "^24.7.0"
     jest-mock "^24.7.0"
     jest-util "^24.7.1"
-
-jest-file-snapshot@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/jest-file-snapshot/-/jest-file-snapshot-0.3.6.tgz#392b86adfed45f695d0d3184d2752df9da5264f3"
-  integrity sha512-/+otGi8yC109jp6Kg4UVaF0MJ2iE4V07jgbvh/+velJa0F35zjMHI7aUpqyphakBwcNgl+ndMix5NpRZOXJ/OA==
-  dependencies:
-    chalk "^2.4.1"
-    filenamify "^2.1.0"
-    jest-diff "^23.6.0"
-    mkdirp "^0.5.1"
-
-jest-get-type@^22.1.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
-  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
 
 jest-get-type@^24.3.0:
   version "24.3.0"
@@ -3958,14 +3914,6 @@ prettier@^1.14.3, prettier@^1.15.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
-pretty-format@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
-  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
-  dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
-
 pretty-format@^24.7.0:
   version "24.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.7.0.tgz#d23106bc2edcd776079c2daa5da02bcb12ed0c10"
@@ -4740,13 +4688,6 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-outer@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
-  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
-  dependencies:
-    escape-string-regexp "^1.0.2"
-
 style-dictionary@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/style-dictionary/-/style-dictionary-2.7.0.tgz#9576257a6829a8c7481a661a70bb8c81d2307599"
@@ -4954,13 +4895,6 @@ trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
   integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
-
-trim-repeated@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
-  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
-  dependencies:
-    escape-string-regexp "^1.0.2"
 
 trim-right@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,6 +2619,11 @@ jest-haste-map@^24.7.1:
   optionalDependencies:
     fsevents "^1.2.7"
 
+jest-in-case@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jest-in-case/-/jest-in-case-1.0.2.tgz#56744b5af33222bd0abab70cf919f1d170ab75cc"
+  integrity sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=
+
 jest-jasmine2@^24.7.1:
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-24.7.1.tgz#01398686dabe46553716303993f3be62e5d9d818"


### PR DESCRIPTION
After thinking about this further, I think this is the right thing to do. 
Given that we have no real guarantee over the integrity of style-dictionary, (and that we can't test their internal build operations), we should probably implement snapshot tests so that we can guarantee that only the outputs that should be affected by a PR are affected. 

The example use case here is: 
- I've changed the javascript transformer in some way 
- I have unit tested the transformer, and I *am* receiving the expected transformation.
- I need to guarantee that on build, my javascript transformer:
  - only affects the javascript outputs; and doesn't have unintentional side effects for the rest of my built files. 
  - doesn't augment my javascript output in unforeseen ways. 

