### PR TITLE
Fix clean step

### DIFF
--- a/build.js
+++ b/build.js
@@ -109,38 +109,23 @@ const config = {
 };
 
 // START THE BUILD
-function clean () {
-  try {
-    const files = globby.sync(path.resolve(__dirname, './packages/**'), { ignore: ['**/package.json', '**/CHANGELOG.md', '**/README.md']});
-    files.forEach(f => {
-      fs.unlinkSync(f);
-    });
-  } catch (e) {
-    throw new Error(e);
-  }
-}
-
 function build() {
-  clean();
-
   const StyleDictionary = StyleDictionaryPackage.extend(config);
+  
   actions.forEach(function (action) {
     StyleDictionary.registerAction(action);
   });
-
   transforms.forEach(function(transform) {
     StyleDictionary.registerTransform(transform);
-  })
-
+  });
   transformGroups.forEach(function(group) {
     StyleDictionary.registerTransformGroup(group);
-  })
-
+  });
   customFormats.forEach(function(format) {
     StyleDictionary.registerFormat(format);
   });
 
-  // StyleDictionary.cleanAllPlatforms();
+  StyleDictionary.cleanAllPlatforms();
   StyleDictionary.buildAllPlatforms();
 }
 

--- a/build.js
+++ b/build.js
@@ -111,7 +111,7 @@ const config = {
 // START THE BUILD
 function build() {
   const StyleDictionary = StyleDictionaryPackage.extend(config);
-  
+
   actions.forEach(function (action) {
     StyleDictionary.registerAction(action);
   });
@@ -124,8 +124,11 @@ function build() {
   customFormats.forEach(function(format) {
     StyleDictionary.registerFormat(format);
   });
-
-  StyleDictionary.cleanAllPlatforms();
+  try {
+    StyleDictionary.cleanAllPlatforms();
+  } catch (e) {
+    console.error(e);
+  }
   StyleDictionary.buildAllPlatforms();
 }
 

--- a/config/actions/entrypoints.js
+++ b/config/actions/entrypoints.js
@@ -1,13 +1,14 @@
 const fs = require('fs');
 const { execSync } = require('child_process');
 const path = require('path');
-const rimraf = require('rimraf');
+const globby = require('globby');
+const findUp = require('find-up');
 
 function setupEntrypoints (dictionary, config) {
   const propertyKeys = Object.keys(dictionary.properties);
-  const destinationPath = path.resolve(__dirname, `../../${config.buildPath}`, 'design-tokens-js');
+  const workspace = findUp.sync(config.buildPath, { type: 'directory' });
+  const destinationPath = path.resolve(__dirname, workspace, 'design-tokens-js');
   propertyKeys.forEach(key => {
-    rimraf.sync(`${destinationPath}/${key}`);
     const data = {
       main: "dist/design-tokens-js.cjs.js",
       module: "dist/design-tokens-js.esm.js",
@@ -20,12 +21,31 @@ function setupEntrypoints (dictionary, config) {
   });
 }
 
-function removeEntrypoints () {
-  const propertyKeys = Object.keys(dictionary.properties);
-  const destinationPath = path.resolve(__dirname, `..${config.buildPath}/design-tokens-js`);
-  propertyKeys.forEach(key => {
-    rimraf.sync(`${destinationPath}/${key}/*`);
+function deleteDirectory (directoryPath) {
+  if (!fs.existsSync(directoryPath)) return;
+  const entryPaths = fs.readdirSync(directoryPath);
+  entryPaths.forEach(entryPath => {
+    if (fs.lstatSync(path.resolve(directoryPath, entryPath)).isDirectory()) {
+      deleteDirectory(path.resolve(directoryPath, entryPath));
+    } else {
+      fs.unlinkSync(path.resolve(directoryPath, entryPath));
+    };
   });
+  fs.rmdirSync(directoryPath);
+}
+
+function removeEntrypoints (dictionary, config) {
+  const propertyKeys = Object.keys(dictionary.properties);
+  const workspace = findUp.sync(config.buildPath, { type: 'directory' });
+  const destinationPath = path.resolve(__dirname, workspace, 'design-tokens-js');
+  const directories = fs.readdirSync(destinationPath)
+    .map(filePath=> path.resolve(destinationPath, filePath))
+    .filter(filePath => {
+      return filePath !== path.resolve(destinationPath, 'package.json')
+       && filePath !== path.resolve(destinationPath, 'CHANGELOG.md');
+    });
+
+  directories.forEach(deleteDirectory);
 }
 
 module.exports = {

--- a/config/customFormats/cjs.js
+++ b/config/customFormats/cjs.js
@@ -1,5 +1,4 @@
 module.exports = (dictionary, config) => {
-
   const reduceValue = (object) => {
     const properties = Object.keys(object);
     if (!properties) return;


### PR DESCRIPTION
We don't need a separate clean() operation.
We now use cleanAllPlatforms from style-dict to clean our directories before build. 

This PR contains: 
- Changes to build.js to do clean operations through StyleDictionary
- Changes to entrypoints to refactor how we clean dists in the design-tokens-js package.

Try catch can be removed once https://github.com/amzn/style-dictionary/pull/277 is merged 